### PR TITLE
Only set vip for controlplane nodes

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -39,10 +39,10 @@ machine:
       routes:
         - network: 0.0.0.0/0
           gateway: {{ include "talm.discovered.default_gateway" . }}
-      {{- with .Values.floatingIP }}
+      {{- if eq .MachineType "controlplane" }}{{ with .Values.floatingIP }}
       vip:
         ip: {{ . }}
-      {{- end }}
+      {{- end }}{{ end }}
 
 
 cluster:


### PR DESCRIPTION
Built talm locally and tested this out, it should fix #7 