### PR TITLE
fix(talm): skip over disks that don't have a wwid

### DIFF
--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "talm.discovered.system_disk_name" }}
 {{- $disk := "" }}
 {{- range .Disks }}
-{{- if eq $disk "" }}
+{{- if and (eq $disk "") .wwid }}
 {{- $disk = .device_name }}
 {{- end }}
 {{- if .system_disk }}


### PR DESCRIPTION
While spinning up new bare metal devices, there were a lot of loop devices present in the machine. Talm didn't detect a system disk and it used the first loop device as a target, causing talos installation to crash and reboot. This commit skips loop devices during the helm template causing the fallback to be the first non-loop device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the logic for determining the system disk name, enhancing the accuracy of disk assignments based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->