### PR TITLE
Introduce --debug option; fix $patch=delete

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -29,6 +29,7 @@ var applyCmdFlags struct {
 	configFiles       []string // -f/--files
 	talosVersion      string
 	withSecrets       string
+	debug             bool
 	kubernetesVersion string
 	dryRun            bool
 	preserve          bool
@@ -53,6 +54,9 @@ var applyCmd = &cobra.Command{
 		}
 		if !cmd.Flags().Changed("kubernetes-version") {
 			applyCmdFlags.kubernetesVersion = Config.TemplateOptions.KubernetesVersion
+		}
+		if !cmd.Flags().Changed("debug") {
+			applyCmdFlags.debug = Config.TemplateOptions.Debug
 		}
 		if !cmd.Flags().Changed("preserve") {
 			applyCmdFlags.preserve = Config.UpgradeOptions.Preserve
@@ -88,6 +92,7 @@ func apply(args []string) func(ctx context.Context, c *client.Client) error {
 				TalosVersion:      applyCmdFlags.talosVersion,
 				WithSecrets:       applyCmdFlags.withSecrets,
 				KubernetesVersion: applyCmdFlags.kubernetesVersion,
+				Debug:             applyCmdFlags.debug,
 			}
 
 			patches := []string{"@" + configFile}
@@ -188,8 +193,8 @@ func init() {
 	applyCmd.Flags().StringSliceVarP(&applyCmdFlags.configFiles, "file", "f", nil, "specify config files or patches in a YAML file (can specify multiple)")
 	applyCmd.Flags().StringVar(&applyCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
 	applyCmd.Flags().StringVar(&applyCmdFlags.withSecrets, "with-secrets", "", "use a secrets file generated using 'gen secrets'")
-
 	applyCmd.Flags().StringVar(&applyCmdFlags.kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
+	applyCmd.Flags().BoolVarP(&applyCmdFlags.debug, "debug", "", false, "show only rendered patches")
 	applyCmd.Flags().BoolVar(&applyCmdFlags.dryRun, "dry-run", false, "check how the config change will be applied in dry-run mode")
 	applyCmd.Flags().DurationVar(&applyCmdFlags.configTryTimeout, "timeout", constants.ConfigTryTimeout, "the config will be rolled back after specified timeout (if try mode is selected)")
 	applyCmd.Flags().StringSliceVar(&applyCmdFlags.certFingerprints, "cert-fingerprint", nil, "list of server certificate fingeprints to accept (defaults to no check)")

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -40,6 +40,7 @@ var Config struct {
 		WithSecrets       string   `yaml:"withSecrets"`
 		KubernetesVersion string   `yaml:"kubernetesVersion"`
 		Full              bool     `yaml:"full"`
+		Debug             bool     `yaml:"debug"`
 	} `yaml:"templateOptions"`
 	ApplyOptions struct {
 		DryRun           bool   `yaml:"preserve"`

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -32,6 +32,7 @@ var templateCmdFlags struct {
 	talosVersion      string
 	withSecrets       string
 	full              bool
+	debug             bool
 	offline           bool
 	kubernetesVersion string
 	inplace           bool
@@ -63,6 +64,9 @@ var templateCmd = &cobra.Command{
 		}
 		if !cmd.Flags().Changed("full") {
 			templateCmdFlags.full = Config.TemplateOptions.Full
+		}
+		if !cmd.Flags().Changed("debug") {
+			templateCmdFlags.debug = Config.TemplateOptions.Debug
 		}
 		if !cmd.Flags().Changed("offline") {
 			templateCmdFlags.offline = Config.TemplateOptions.Offline
@@ -199,6 +203,7 @@ func generateOutput(ctx context.Context, c *client.Client, args []string) (strin
 		TalosVersion:      templateCmdFlags.talosVersion,
 		WithSecrets:       templateCmdFlags.withSecrets,
 		Full:              templateCmdFlags.full,
+		Debug:             templateCmdFlags.debug,
 		Root:              Config.RootDir,
 		Offline:           templateCmdFlags.offline,
 		KubernetesVersion: templateCmdFlags.kubernetesVersion,
@@ -234,6 +239,7 @@ func init() {
 	templateCmd.Flags().StringVar(&templateCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
 	templateCmd.Flags().StringVar(&templateCmdFlags.withSecrets, "with-secrets", "", "use a secrets file generated using 'gen secrets'")
 	templateCmd.Flags().BoolVarP(&templateCmdFlags.full, "full", "", false, "show full resulting config, not only patch")
+	templateCmd.Flags().BoolVarP(&templateCmdFlags.debug, "debug", "", false, "show only rendered patches")
 	templateCmd.Flags().BoolVarP(&templateCmdFlags.offline, "offline", "", false, "disable gathering information and lookup functions")
 	templateCmd.Flags().StringVar(&templateCmdFlags.kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a `--debug` flag to `apply` and `template` commands
  - Enhanced configuration output with optional detailed debugging information

- **Improvements**
  - Improved visibility into configuration generation and patch application processes
  - Added more granular control over command output verbosity

- **Configuration**
  - New `debug` option available in configuration files and command-line arguments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->