### PR TITLE
cozystack: disable nodeCIDRs allocation

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -103,6 +103,12 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+      {{- if .Values.allocateNodeCIDRs }}
+      allocate-node-cidrs: true
+      cluster-cidr: "{{ join "," .Values.podSubnets }}"
+      {{- else }}
+      allocate-node-cidrs: false
+      {{- end }}
   scheduler:
     extraArgs:
       bind-address: 0.0.0.0

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -11,3 +11,4 @@ advertisedSubnets:
 oidcIssuerUrl: ""
 certSANs: []
 nr_hugepages: 0
+allocateNodeCIDRs: false


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New configuration option to control automatic node CIDR allocation behavior, enabling manual network management customization for specific deployment scenarios and infrastructure requirements.
  * New configuration option to specify custom cluster CIDR ranges, providing flexibility in network architecture design and optimized IP address space allocation across different cluster environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->