### PR TITLE
Add preferLocalEndpoint option

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -97,7 +97,11 @@ cluster:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
   clusterName: "{{ .Chart.Name }}"
   controlPlane:
+    {{- if and (eq .MachineType "controlplane") .Values.preferLocalEndpoint }}
+    endpoint: "https://127.0.0.1:6443"
+    {{- else }}
     endpoint: "{{ .Values.endpoint }}"
+    {{- end }}
   {{- if eq .MachineType "controlplane" }}
   allowSchedulingOnControlPlanes: true
   controllerManager:

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -1,4 +1,5 @@
 endpoint: "https://192.168.100.10:6443"
+preferLocalEndpoint: false
 clusterDomain: cozy.local
 floatingIP: 192.168.100.10
 image: "ghcr.io/cozystack/cozystack/talos:v1.11.3"


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to prefer local cluster endpoints, enabling users to conditionally route traffic to local endpoints based on machine type when desired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->