### PR TITLE
docs(readme): add Homebrew installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ with the official tools like talosctl and Omni.
 ## Installation
 
 ### Homebrew
+For macOS and Linux users, the recommended way to install talm is with Homebrew.
+
 
 ```bash
 brew install talm


### PR DESCRIPTION
## Summary

- Add Homebrew as a primary installation method in README
- Reorganize installation section with subsections for different methods

## Details

Talm has been accepted into Homebrew core, so users can now install it with a simple `brew install talm`. This is the easiest installation method for macOS and Linux users with Homebrew.

## Test plan

- [x] Verify `brew install talm` works correctly
- [x] Check README renders properly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive installation instructions with multiple methods: Homebrew package manager support and direct binary installation via automated script with links to GitHub releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->