### PR TITLE
feat(init)!: require --name flag for cluster name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Create new project
 ```bash
 mkdir newcluster
 cd newcluster
-talm init -p cozystack
+talm init -p cozystack -N myawesomecluster
 ```
 
 Boot Talos Linux node, let's say it has address `1.2.3.4`

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -80,7 +80,7 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("preset is required (use --preset or -p flag)")
 		}
 		if initCmdFlags.name == "" {
-			return fmt.Errorf("cluster name is required (use --name flag)")
+			return fmt.Errorf("cluster name is required (use --name or -N flag)")
 		}
 		return nil
 	},
@@ -273,11 +273,6 @@ var initCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "No files to decrypt.\n")
 			}
 			return nil
-		}
-
-		// Preset is required for normal init (not --encrypt or --decrypt)
-		if initCmdFlags.preset == "" {
-			return fmt.Errorf("preset is required (use --preset or -p flag)")
 		}
 
 		// If encrypted file exists, decrypt it
@@ -677,8 +672,8 @@ func updateTalmLibraryChart() error {
 
 func init() {
 	initCmd.Flags().StringVar(&initCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
-	initCmd.Flags().StringVarP(&initCmdFlags.preset, "preset", "p", "", "specify preset to generate files (not required with --encrypt, --decrypt, or --update)")
-	initCmd.Flags().StringVar(&initCmdFlags.name, "name", "", "cluster name (required unless using --encrypt, --decrypt, or --update)")
+	initCmd.Flags().StringVarP(&initCmdFlags.preset, "preset", "p", "", "preset for file generation (not required with --encrypt, --decrypt, or --update)")
+	initCmd.Flags().StringVarP(&initCmdFlags.name, "name", "N", "", "cluster name (not required with --encrypt, --decrypt, or --update)")
 	initCmd.Flags().BoolVar(&initCmdFlags.force, "force", false, "will overwrite existing files")
 	initCmd.Flags().BoolVarP(&initCmdFlags.update, "update", "u", false, "update Talm library chart")
 	// Override persistent -e flag for init command to use for encrypt


### PR DESCRIPTION
## Summary

- Add required `--name` flag to `talm init` command
- Remove automatic cluster name detection from directory name
- Users must now explicitly specify the cluster name

## Breaking Change

The `talm init` command now requires the `--name` flag to be specified explicitly. Previously, the cluster name was automatically derived from the current directory name.

**Before:**
```bash
cd my-cluster && talm init --preset generic
# cluster name = "my-cluster" (from directory)
```

**After:**
```bash
talm init --preset generic --name my-cluster
```

Closes #56

## Test plan

- [x] `talm init` without flags shows error for missing `--preset`
- [x] `talm init --preset generic` shows error for missing `--name`
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced --name (-N) flag for the init command, enabling explicit cluster name specification.
  * Refined validation behavior for encryption, decryption, and update operations.

* **Documentation**
  * Updated initialization command examples in README to demonstrate the new --name flag usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->