### PR TITLE
fix(kubeconfig): remove unused arg [local-path] from help text

### DIFF
--- a/pkg/commands/kubeconfig_handler.go
+++ b/pkg/commands/kubeconfig_handler.go
@@ -29,6 +29,12 @@ func wrapKubeconfigCommand(wrappedCmd *cobra.Command, originalRunE func(*cobra.C
 	// Add --login flag to update system kubeconfig file instead of local one
 	wrappedCmd.Flags().BoolP("login", "l", false, "update system kubeconfig file, not local one")
 
+	// Fix help text for unused arg [local-path] from talosctl kubeconfig command
+	wrappedCmd.Use = "kubeconfig"
+	wrappedCmd.Long = `Download the admin kubeconfig from the node.
+If merge flag is true, config will be merged with ~/.kube/config.
+Otherwise, kubeconfig will be written to PWD.`
+
 	wrappedCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// Ensure project root is detected
 		if !Config.RootDirExplicit {


### PR DESCRIPTION
## Summary
Fixed `kubeconfig` help text, now it's not describes unused `local-path` arg wrapped by original talosctl cmd text:
```
Usage:
  talm kubeconfig [flags]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced help text for the kubeconfig command with clearer descriptions of admin kubeconfig download behavior, merge vs. non-merge options, and output location details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->