### PR TITLE
feat(cozystack): enable allocateNodeCIDRs by default

### DIFF
--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -11,4 +11,4 @@ advertisedSubnets:
 oidcIssuerUrl: ""
 certSANs: []
 nr_hugepages: 0
-allocateNodeCIDRs: false
+allocateNodeCIDRs: true


### PR DESCRIPTION
## Summary

- Enable automatic node CIDR allocation for all clusters by default

This change sets `allocateNodeCIDRs: true` in the default values, ensuring that node CIDRs are allocated automatically without requiring explicit configuration.

## Test plan

- [x] Verify cluster provisioning works with the new default
- [x] Confirm kube-controller-manager receives correct allocate-node-cidrs flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default cluster networking configuration to enable automatic node CIDR allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->