### PR TITLE
feat(helpers): add bond interface discovery helpers

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -75,7 +75,12 @@ machine:
     {{- if $existingInterfacesConfiguration }}
     {{- $existingInterfacesConfiguration | nindent 4 }}
     {{- else }}
-    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
+    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+    - interface: {{ $defaultLinkName }}
+      {{- $bondConfig := include "talm.discovered.bond_config" $defaultLinkName }}
+      {{- if $bondConfig }}
+      {{- $bondConfig | nindent 6 }}
+      {{- end }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -21,7 +21,12 @@ machine:
     {{- if $existingInterfacesConfiguration }}
     {{- $existingInterfacesConfiguration | nindent 4 }}
     {{- else }}
-    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
+    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+    - interface: {{ $defaultLinkName }}
+      {{- $bondConfig := include "talm.discovered.bond_config" $defaultLinkName }}
+      {{- if $bondConfig }}
+      {{- $bondConfig | nindent 6 }}
+      {{- end }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0


### PR DESCRIPTION
## Summary

- Add template helpers for automatic bond interface discovery from Talos links resource
- Enable bond configuration generation in insecure/maintenance mode without machineconfig access

## New helpers

- `talm.discovered.bond_slaves` - finds slave interfaces by masterIndex
- `talm.discovered.bond_config` - generates bond section from bondMaster spec  
- `talm.discovered.is_bond` - checks if interface is a bond

## Changes

- `charts/talm/templates/_helpers.tpl` - add bond discovery helpers
- `charts/generic/templates/_helpers.tpl` - use bond_config in interface generation
- `charts/cozystack/templates/_helpers.tpl` - use bond_config in interface generation

## Example output

```yaml
interfaces:
  - interface: bond0
    bond:
      interfaces:
        - enp1s0f1
        - enp2s0f1
      mode: 802.3ad
      xmitHashPolicy: layer3+4
      lacpRate: slow
      miimon: 100
      updelay: 200
      downdelay: 200
    addresses:
      - 23.109.46.209/31
    routes:
      - network: 0.0.0.0/0
        gateway: 23.109.46.208
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for network bond configuration on interfaces, enabling optional bond settings for master/slave interface management.
  * Bond configuration is conditionally applied when bond relationships are discovered, while preserving existing address and route configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->