### PR TITLE
fix(lookup): initialize map to prevent nil map assignment panic

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -612,6 +612,7 @@ func newLookupFunction(ctx context.Context, c *client.Client) func(resource stri
 
 			res, err := extractResourceData(r)
 			if err != nil {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("resource %s/%s: %w", r.Metadata().Type(), r.Metadata().ID(), err))
 				return nil
 			}
 
@@ -625,6 +626,9 @@ func newLookupFunction(ctx context.Context, c *client.Client) func(resource stri
 		helperErr := helpers.ForEachResource(ctx, c, callbackRD, callbackResource, namespace, kind, id)
 		if helperErr != nil {
 			return map[string]interface{}{}, helperErr
+		}
+		if err := multiErr.ErrorOrNil(); err != nil {
+			return map[string]interface{}{}, err
 		}
 		if len(resources) == 0 {
 			return map[string]interface{}{}, nil


### PR DESCRIPTION
## Summary

Fix panic "assignment to entry in nil map" when lookup function processes resources with empty or malformed metadata.

Fixes #95

## Problem

In `extractResourceData`, the `res` variable was declared as:
```go
var res map[string]interface{}
```

This creates a nil map. If `yaml.Unmarshal` doesn't populate it (e.g., due to empty or malformed metadata), the subsequent line `res["spec"] = unmarshalledData` panics.

## Solution

Initialize the map explicitly:
```go
res := make(map[string]interface{})
```

This ensures the map is never nil, preventing the panic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for resource operations with more detailed and contextual error messages. When resource processing fails, users now receive clearer information identifying which resource encountered the issue and specific details about what went wrong, improving troubleshooting and debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->