### PR TITLE
fix(network): correct multi-NIC discovery and add per-link helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 talm
 dist/
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 talm
 dist/
-.claude/worktrees/

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -183,6 +183,7 @@ nameservers:
   []
 {{- end }}
 {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+{{- if $defaultLinkName }}
 {{- $isVlan := include "talm.discovered.is_vlan" $defaultLinkName }}
 {{- $parentLinkName := "" }}
 {{- if $isVlan }}
@@ -269,6 +270,7 @@ name: {{ .Values.floatingIP | quote }}
 link: {{ $vipLinkName }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /* Shared legacy network section for machine.network */ -}}
 {{- define "talos.config.network.legacy" }}
@@ -276,12 +278,13 @@ link: {{ $vipLinkName }}
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
-    interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
+    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+    {{- if or $existingInterfacesConfiguration $defaultLinkName }}
+    interfaces:
     {{- if $existingInterfacesConfiguration }}
     {{- $existingInterfacesConfiguration | nindent 4 }}
     {{- else }}
-    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
     {{- $isVlan := include "talm.discovered.is_vlan" $defaultLinkName }}
     {{- $parentLinkName := "" }}
     {{- if $isVlan }}
@@ -317,6 +320,7 @@ link: {{ $vipLinkName }}
         ip: {{ .Values.floatingIP }}
       {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -106,6 +106,7 @@ nameservers:
   []
 {{- end }}
 {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+{{- if $defaultLinkName }}
 {{- $isVlan := include "talm.discovered.is_vlan" $defaultLinkName }}
 {{- $parentLinkName := "" }}
 {{- if $isVlan }}
@@ -192,6 +193,7 @@ name: {{ .Values.floatingIP | quote }}
 link: {{ $vipLinkName }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /* Shared legacy network section for machine.network */ -}}
 {{- define "talos.config.network.legacy" }}
@@ -199,12 +201,13 @@ link: {{ $vipLinkName }}
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
-    interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
+    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
+    {{- if or $existingInterfacesConfiguration $defaultLinkName }}
+    interfaces:
     {{- if $existingInterfacesConfiguration }}
     {{- $existingInterfacesConfiguration | nindent 4 }}
     {{- else }}
-    {{- $defaultLinkName := include "talm.discovered.default_link_name_by_gateway" . }}
     {{- $isVlan := include "talm.discovered.is_vlan" $defaultLinkName }}
     {{- $parentLinkName := "" }}
     {{- if $isVlan }}
@@ -240,6 +243,7 @@ link: {{ $vipLinkName }}
         ip: {{ .Values.floatingIP }}
       {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -126,7 +126,7 @@
 {{- define "talm.discovered.default_link_bus_by_gateway" }}
 {{- range (lookup "routes" "" "").items }}
 {{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
-{{- (lookup "links" "" .spec.outLinkName).spec.hardwareAddr }}
+{{- (lookup "links" "" .spec.outLinkName).spec.busPath }}
 {{- break }}
 {{- end }}
 {{- end }}
@@ -282,8 +282,10 @@ vlans:
   remain wrappers that resolve the primary link and call into these.
 */ -}}
 
-{{- /* JSON list of physical link names (raw NICs only — not bond/vlan masters). */ -}}
-{{- define "talm.discovered.physical_links" -}}
+{{- /* JSON list of physical link names (raw NICs only — not bond/vlan masters).
+       Renamed from `physical_links` to avoid collision with the older
+       `physical_links_info` helper, which renders YAML comments. */ -}}
+{{- define "talm.discovered.physical_link_names" -}}
 {{- $names := list -}}
 {{- range (lookup "links" "" "").items -}}
 {{- if and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" (.metadata.id | toString)) -}}
@@ -295,7 +297,7 @@ vlans:
 
 {{- /* JSON list of every link a user template can configure: physical NICs
        plus bond / vlan / bridge top-level links. */ -}}
-{{- define "talm.discovered.configurable_links" -}}
+{{- define "talm.discovered.configurable_link_names" -}}
 {{- $names := list -}}
 {{- range (lookup "links" "" "").items -}}
 {{- $isPhysical := and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" (.metadata.id | toString)) -}}
@@ -308,15 +310,17 @@ vlans:
 {{- end -}}
 
 {{- /* JSON list of CIDR addresses configured on the given link, excluding
-       kernel-managed scopes (host loopback, link-local, nowhere). Both IPv4
-       and IPv6 globally-scoped addresses are returned; the caller is
-       responsible for filtering by family or stripping VIPs if needed. */ -}}
+       kernel-managed scopes (host loopback, link-local, nowhere) and
+       addresses with no scope set at all. Both IPv4 and IPv6 globally-scoped
+       addresses are returned; the caller is responsible for filtering by
+       family or stripping VIPs if needed. */ -}}
 {{- define "talm.discovered.addresses_by_link" -}}
 {{- $linkName := . -}}
 {{- $addresses := list -}}
 {{- range (lookup "addresses" "" "").items -}}
+{{- $hasScope := and .spec.scope (ne (.spec.scope | toString) "") -}}
 {{- $skip := has (.spec.scope | toString) (list "host" "link" "nowhere") -}}
-{{- if and (eq .spec.linkName $linkName) (not $skip) -}}
+{{- if and (eq .spec.linkName $linkName) $hasScope (not $skip) -}}
 {{- $addresses = append $addresses .spec.address -}}
 {{- end -}}
 {{- end -}}
@@ -339,37 +343,43 @@ vlans:
 
 {{- /* JSON list of non-default routes on the given link. Each entry is a flat
        map {dst, gateway, family, table, priority} so consumers can
-       fromJsonArray + range + dig. Missing route fields are emitted as empty
-       strings so consumers never see the literal "<nil>". */ -}}
+       fromJsonArray + range + dig. Absent fields are emitted as empty
+       strings; present fields including the integer 0 (e.g. priority: 0)
+       round-trip through toString. */ -}}
 {{- define "talm.discovered.routes_by_link" -}}
 {{- $linkName := . -}}
 {{- $routes := list -}}
 {{- range (lookup "routes" "" "").items -}}
 {{- if and (eq .spec.outLinkName $linkName) (not (eq .spec.dst "")) -}}
-{{- $entry := dict
-    "dst" .spec.dst
-    "gateway" (default "" .spec.gateway | toString)
-    "family" (default "" .spec.family | toString)
-    "table" (default "" .spec.table | toString)
-    "priority" (default "" .spec.priority | toString) -}}
+{{- $gateway := "" -}}
+{{- if not (kindIs "invalid" .spec.gateway) -}}{{- $gateway = printf "%v" .spec.gateway -}}{{- end -}}
+{{- $family := "" -}}
+{{- if not (kindIs "invalid" .spec.family) -}}{{- $family = printf "%v" .spec.family -}}{{- end -}}
+{{- $table := "" -}}
+{{- if not (kindIs "invalid" .spec.table) -}}{{- $table = printf "%v" .spec.table -}}{{- end -}}
+{{- $priority := "" -}}
+{{- if not (kindIs "invalid" .spec.priority) -}}{{- $priority = printf "%v" .spec.priority -}}{{- end -}}
+{{- $entry := dict "dst" .spec.dst "gateway" $gateway "family" $family "table" $table "priority" $priority -}}
 {{- $routes = append $routes $entry -}}
 {{- end -}}
 {{- end -}}
 {{- toJson $routes -}}
 {{- end -}}
 
-{{- /* Scalar MAC address for the given link, or empty. */ -}}
+{{- /* Scalar MAC address for the given link, or empty if the link or its
+       spec is missing (test mocks may return {} for unknown ids). */ -}}
 {{- define "talm.discovered.mac_by_link" -}}
 {{- $link := lookup "links" "" . -}}
-{{- if $link -}}
+{{- if and $link $link.spec -}}
 {{- $link.spec.hardwareAddr | toString -}}
 {{- end -}}
 {{- end -}}
 
-{{- /* Scalar PCI / bus path for the given link, or empty. */ -}}
+{{- /* Scalar PCI / bus path for the given link, or empty if the link or its
+       spec is missing. */ -}}
 {{- define "talm.discovered.bus_by_link" -}}
 {{- $link := lookup "links" "" . -}}
-{{- if $link -}}
+{{- if and $link $link.spec -}}
 {{- $link.spec.busPath | toString -}}
 {{- end -}}
 {{- end -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -307,26 +307,30 @@ vlans:
 {{- toJson $names -}}
 {{- end -}}
 
-{{- /* JSON list of CIDR addresses configured on the given link (any family),
-       excluding host-scoped addresses. Caller is responsible for filtering
-       VIPs or family if needed. */ -}}
+{{- /* JSON list of CIDR addresses configured on the given link, excluding
+       kernel-managed scopes (host loopback, link-local, nowhere). Both IPv4
+       and IPv6 globally-scoped addresses are returned; the caller is
+       responsible for filtering by family or stripping VIPs if needed. */ -}}
 {{- define "talm.discovered.addresses_by_link" -}}
 {{- $linkName := . -}}
 {{- $addresses := list -}}
 {{- range (lookup "addresses" "" "").items -}}
-{{- if and (eq .spec.linkName $linkName) (not (eq .spec.scope "host")) -}}
+{{- $skip := has (.spec.scope | toString) (list "host" "link" "nowhere") -}}
+{{- if and (eq .spec.linkName $linkName) (not $skip) -}}
 {{- $addresses = append $addresses .spec.address -}}
 {{- end -}}
 {{- end -}}
 {{- toJson $addresses -}}
 {{- end -}}
 
-{{- /* Scalar gateway IP for the default route (dst="", main table) on the
-       given link. Empty if no default route uses this link. */ -}}
+{{- /* Scalar IPv4 gateway for the default route (dst="", main table) on the
+       given link. Empty if the link has no IPv4 default route. IPv4-only by
+       convention to avoid family/address mismatch on dual-stack nodes — add
+       a sibling helper for IPv6 if you need it. */ -}}
 {{- define "talm.discovered.gateway_by_link" -}}
 {{- $linkName := . -}}
 {{- range (lookup "routes" "" "").items -}}
-{{- if and (eq .spec.outLinkName $linkName) (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") -}}
+{{- if and (eq .spec.outLinkName $linkName) (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") (eq (.spec.family | toString) "inet4") -}}
 {{- .spec.gateway -}}
 {{- break -}}
 {{- end -}}
@@ -335,13 +339,19 @@ vlans:
 
 {{- /* JSON list of non-default routes on the given link. Each entry is a flat
        map {dst, gateway, family, table, priority} so consumers can
-       fromJsonArray + range + dig. */ -}}
+       fromJsonArray + range + dig. Missing route fields are emitted as empty
+       strings so consumers never see the literal "<nil>". */ -}}
 {{- define "talm.discovered.routes_by_link" -}}
 {{- $linkName := . -}}
 {{- $routes := list -}}
 {{- range (lookup "routes" "" "").items -}}
 {{- if and (eq .spec.outLinkName $linkName) (not (eq .spec.dst "")) -}}
-{{- $entry := dict "dst" .spec.dst "gateway" (.spec.gateway | toString) "family" (.spec.family | toString) "table" (.spec.table | toString) "priority" (.spec.priority | toString) -}}
+{{- $entry := dict
+    "dst" .spec.dst
+    "gateway" (default "" .spec.gateway | toString)
+    "family" (default "" .spec.family | toString)
+    "table" (default "" .spec.table | toString)
+    "priority" (default "" .spec.priority | toString) -}}
 {{- $routes = append $routes $entry -}}
 {{- end -}}
 {{- end -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -270,3 +270,106 @@ vlans:
   - vlanId: {{ $link.spec.vlan.vlanID }}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+  Multi-NIC discovery helpers (#125).
+
+  The `default_*_by_gateway` family above resolves only the link carrying the
+  default route (primary). Templates targeting nodes with secondary NICs
+  (storage links on a control-plane, second uplink, etc.) need to enumerate
+  every physical link and read its addresses/routes/MAC by name. The helpers
+  below are the by-name building blocks; existing default_*_by_gateway helpers
+  remain wrappers that resolve the primary link and call into these.
+*/ -}}
+
+{{- /* JSON list of physical link names (raw NICs only — not bond/vlan masters). */ -}}
+{{- define "talm.discovered.physical_links" -}}
+{{- $names := list -}}
+{{- range (lookup "links" "" "").items -}}
+{{- if and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" (.metadata.id | toString)) -}}
+{{- $names = append $names .metadata.id -}}
+{{- end -}}
+{{- end -}}
+{{- toJson $names -}}
+{{- end -}}
+
+{{- /* JSON list of every link a user template can configure: physical NICs
+       plus bond / vlan / bridge top-level links. */ -}}
+{{- define "talm.discovered.configurable_links" -}}
+{{- $names := list -}}
+{{- range (lookup "links" "" "").items -}}
+{{- $isPhysical := and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" (.metadata.id | toString)) -}}
+{{- $isVirtual := has (.spec.kind | toString) (list "bond" "vlan" "bridge") -}}
+{{- if or $isPhysical $isVirtual -}}
+{{- $names = append $names .metadata.id -}}
+{{- end -}}
+{{- end -}}
+{{- toJson $names -}}
+{{- end -}}
+
+{{- /* JSON list of CIDR addresses configured on the given link (any family),
+       excluding host-scoped addresses. Caller is responsible for filtering
+       VIPs or family if needed. */ -}}
+{{- define "talm.discovered.addresses_by_link" -}}
+{{- $linkName := . -}}
+{{- $addresses := list -}}
+{{- range (lookup "addresses" "" "").items -}}
+{{- if and (eq .spec.linkName $linkName) (not (eq .spec.scope "host")) -}}
+{{- $addresses = append $addresses .spec.address -}}
+{{- end -}}
+{{- end -}}
+{{- toJson $addresses -}}
+{{- end -}}
+
+{{- /* Scalar gateway IP for the default route (dst="", main table) on the
+       given link. Empty if no default route uses this link. */ -}}
+{{- define "talm.discovered.gateway_by_link" -}}
+{{- $linkName := . -}}
+{{- range (lookup "routes" "" "").items -}}
+{{- if and (eq .spec.outLinkName $linkName) (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") -}}
+{{- .spec.gateway -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* JSON list of non-default routes on the given link. Each entry is a flat
+       map {dst, gateway, family, table, priority} so consumers can
+       fromJsonArray + range + dig. */ -}}
+{{- define "talm.discovered.routes_by_link" -}}
+{{- $linkName := . -}}
+{{- $routes := list -}}
+{{- range (lookup "routes" "" "").items -}}
+{{- if and (eq .spec.outLinkName $linkName) (not (eq .spec.dst "")) -}}
+{{- $entry := dict "dst" .spec.dst "gateway" (.spec.gateway | toString) "family" (.spec.family | toString) "table" (.spec.table | toString) "priority" (.spec.priority | toString) -}}
+{{- $routes = append $routes $entry -}}
+{{- end -}}
+{{- end -}}
+{{- toJson $routes -}}
+{{- end -}}
+
+{{- /* Scalar MAC address for the given link, or empty. */ -}}
+{{- define "talm.discovered.mac_by_link" -}}
+{{- $link := lookup "links" "" . -}}
+{{- if $link -}}
+{{- $link.spec.hardwareAddr | toString -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Scalar PCI / bus path for the given link, or empty. */ -}}
+{{- define "talm.discovered.bus_by_link" -}}
+{{- $link := lookup "links" "" . -}}
+{{- if $link -}}
+{{- $link.spec.busPath | toString -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* YAML fragment `busPath: <path>` for use as a Talos deviceSelector by
+       link name. Prefer this over emitting `interface:` when you need the
+       config to be portable across renames (e.g. predictable network names). */ -}}
+{{- define "talm.discovered.link_selector_by_name" -}}
+{{- $link := lookup "links" "" . -}}
+{{- if and $link $link.spec.busPath -}}
+busPath: {{ $link.spec.busPath }}
+{{- end -}}
+{{- end -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -341,11 +341,13 @@ vlans:
 {{- end -}}
 {{- end -}}
 
-{{- /* JSON list of non-default routes on the given link. Each entry is a flat
-       map {dst, gateway, family, table, priority} so consumers can
-       fromJsonArray + range + dig. Absent fields are emitted as empty
-       strings; present fields including the integer 0 (e.g. priority: 0)
-       round-trip through toString. */ -}}
+{{- /* JSON list of non-default routes on the given link, across all
+       routing tables (the `table` field is included so callers can
+       filter — gateway_by_link narrows to table=main, this helper does
+       not). Each entry is a flat map {dst, gateway, family, table,
+       priority} so consumers can fromJsonArray + range + dig. Absent
+       fields are emitted as empty strings; present fields including the
+       integer 0 (e.g. priority: 0) round-trip through toString. */ -}}
 {{- define "talm.discovered.routes_by_link" -}}
 {{- $linkName := . -}}
 {{- $routes := list -}}
@@ -366,20 +368,24 @@ vlans:
 {{- toJson $routes -}}
 {{- end -}}
 
-{{- /* Scalar MAC address for the given link, or empty if the link or its
-       spec is missing (test mocks may return {} for unknown ids). */ -}}
+{{- /* Scalar MAC address for the given link, or empty if the link is
+       missing or has no hardwareAddr (virtual links have spec but may
+       lack the field; test mocks may return {} for unknown ids). The
+       field guard prevents `nil | toString` from rendering "<nil>". */ -}}
 {{- define "talm.discovered.mac_by_link" -}}
 {{- $link := lookup "links" "" . -}}
-{{- if and $link $link.spec -}}
+{{- if and $link $link.spec $link.spec.hardwareAddr -}}
 {{- $link.spec.hardwareAddr | toString -}}
 {{- end -}}
 {{- end -}}
 
-{{- /* Scalar PCI / bus path for the given link, or empty if the link or its
-       spec is missing. */ -}}
+{{- /* Scalar PCI / bus path for the given link, or empty if the link is
+       missing or has no busPath (virtual links such as bonds expose a
+       spec without a busPath). The field guard prevents
+       `nil | toString` from rendering "<nil>". */ -}}
 {{- define "talm.discovered.bus_by_link" -}}
 {{- $link := lookup "links" "" . -}}
-{{- if and $link $link.spec -}}
+{{- if and $link $link.spec $link.spec.busPath -}}
 {{- $link.spec.busPath | toString -}}
 {{- end -}}
 {{- end -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -69,6 +69,7 @@
 {{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
 {{- $linkName = .spec.outLinkName }}
 {{- $family = .spec.family }}
+{{- break }}
 {{- end }}
 {{- end }}
 {{- $addresses := list }}
@@ -106,31 +107,34 @@
 
 {{- define "talm.discovered.default_link_name_by_gateway" }}
 {{- range (lookup "routes" "" "").items }}
-{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) }}
+{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
 {{- .spec.outLinkName }}
+{{- break }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "talm.discovered.default_link_address_by_gateway" }}
 {{- range (lookup "routes" "" "").items }}
-{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) }}
+{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
 {{- (lookup "links" "" .spec.outLinkName).spec.hardwareAddr }}
+{{- break }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "talm.discovered.default_link_bus_by_gateway" }}
 {{- range (lookup "routes" "" "").items }}
-{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) }}
+{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
 {{- (lookup "links" "" .spec.outLinkName).spec.hardwareAddr }}
+{{- break }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "talm.discovered.default_link_selector_by_gateway" }}
 {{- range (lookup "routes" "" "").items }}
-{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) }}
+{{- if and (eq .spec.dst "") (not (eq .spec.gateway "")) (eq .spec.table "main") }}
 {{- with (lookup "links" "" .spec.outLinkName) }}
 busPath: {{ .spec.busPath }}
 {{- break }}

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -1387,6 +1387,8 @@ gw_eth1={{ include "talm.discovered.gateway_by_link" "eth1" }}
 routes_eth1={{ include "talm.discovered.routes_by_link" "eth1" }}
 mac_eth1={{ include "talm.discovered.mac_by_link" "eth1" }}
 bus_eth1={{ include "talm.discovered.bus_by_link" "eth1" }}
+mac_bond0={{ include "talm.discovered.mac_by_link" "bond0" }}
+bus_bond0={{ include "talm.discovered.bus_by_link" "bond0" }}
 mac_unknown={{ include "talm.discovered.mac_by_link" "doesnotexist" }}
 bus_unknown={{ include "talm.discovered.bus_by_link" "doesnotexist" }}
 selector_eth1=
@@ -1435,6 +1437,12 @@ selector_eth1=
 	assertNotContains(t, output, `\u003cnil\u003e`)
 	assertContains(t, output, "mac_eth1=aa:bb:cc:dd:ee:01")
 	assertContains(t, output, "bus_eth1=pci-0000:00:1f.1")
+	// Virtual link with a present spec but missing busPath: a present-spec
+	// path through bus_by_link must not surface "<nil>" via `nil | toString`.
+	// bond0's fixture has hardwareAddr but no busPath, so mac_bond0 returns
+	// the synthetic MAC and bus_bond0 must be empty.
+	assertContains(t, output, "mac_bond0=aa:bb:cc:dd:ee:ff")
+	assertContains(t, output, "bus_bond0=\n")
 	// Unknown link must yield empty MAC/busPath even when the lookup mock
 	// returns an empty map (real Helm returns nil; defensive on both).
 	assertContains(t, output, "mac_unknown=\n")

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -135,6 +135,65 @@ func renderChartTemplate(t *testing.T, chartPath string, templateFile string, ta
 	return result
 }
 
+// renderChartTemplateWithLookup renders a chart with a custom LookupFunc (or
+// offline empty-map default when nil). Restores the previous LookupFunc on
+// cleanup so tests don't leak state.
+func renderChartTemplateWithLookup(t *testing.T, chartPath string, templateFile string, lookup func(string, string, string) (map[string]any, error), talosVersion ...string) string {
+	t.Helper()
+
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+
+	if lookup != nil {
+		helmEngine.LookupFunc = lookup
+	} else {
+		helmEngine.LookupFunc = func(string, string, string) (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+	}
+
+	chrt, err := loader.LoadDir(chartPath)
+	if err != nil {
+		t.Fatalf("failed to load chart from %s: %v", chartPath, err)
+	}
+
+	tv := ""
+	if len(talosVersion) > 0 {
+		tv = talosVersion[0]
+	}
+
+	values := cloneValues(chrt.Values)
+	if v, _ := values["endpoint"].(string); v == "" {
+		values["endpoint"] = testEndpoint
+	}
+	if arr, ok := values["advertisedSubnets"].([]any); !ok || len(arr) == 0 {
+		values["advertisedSubnets"] = []any{testAdvertisedSubnet}
+	}
+
+	rootValues := chartutil.Values{
+		"Values":       values,
+		"TalosVersion": tv,
+	}
+
+	eng := helmEngine.Engine{}
+	out, err := eng.Render(chrt, rootValues)
+	if err != nil {
+		t.Fatalf("failed to render chart: %v", err)
+	}
+
+	key := path.Join(chrt.Name(), templateFile)
+	result, ok := out[key]
+	if !ok {
+		var keys []string
+		for k := range out {
+			keys = append(keys, k)
+		}
+		t.Fatalf("template %s not found in output, available keys: %v", key, keys)
+	}
+
+	return result
+}
+
 // assertContains checks that the output contains the expected substring.
 func assertContains(t *testing.T, output string, substr string) {
 	t.Helper()
@@ -265,7 +324,7 @@ func TestLegacyGeneric_Worker(t *testing.T) {
 // --- Multi-doc format tests for cozystack (v1.12+) ---
 
 func TestMultiDocCozystack_ControlPlane(t *testing.T) {
-	output := renderChartTemplate(t, "../../charts/cozystack", "templates/controlplane.yaml", "v1.12")
+	output := renderChartTemplateWithLookup(t, "../../charts/cozystack", "templates/controlplane.yaml", simpleNicLookup(), "v1.12")
 
 	// Multi-doc: machine section retains non-deprecated fields
 	assertContains(t, output, "machine:")
@@ -336,7 +395,7 @@ func TestMultiDocCozystack_Worker(t *testing.T) {
 
 func TestMultiDocCozystack_LegacyFallback(t *testing.T) {
 	// v1.11 should produce legacy format even for cozystack chart
-	output := renderChartTemplate(t, "../../charts/cozystack", "templates/controlplane.yaml", "v1.11")
+	output := renderChartTemplateWithLookup(t, "../../charts/cozystack", "templates/controlplane.yaml", simpleNicLookup(), "v1.11")
 
 	// Legacy format present
 	assertContains(t, output, "    interfaces:")
@@ -432,7 +491,7 @@ func TestMultiDocCozystack_NrHugepages(t *testing.T) {
 // --- Multi-doc format tests for generic (v1.12+) ---
 
 func TestMultiDocGeneric_ControlPlane(t *testing.T) {
-	output := renderChartTemplate(t, "../../charts/generic", "templates/controlplane.yaml", "v1.12")
+	output := renderChartTemplateWithLookup(t, "../../charts/generic", "templates/controlplane.yaml", simpleNicLookup(), "v1.12")
 
 	// Multi-doc: machine section still present but WITHOUT legacy network fields
 	assertContains(t, output, "machine:")
@@ -460,7 +519,7 @@ func TestMultiDocGeneric_ControlPlane(t *testing.T) {
 }
 
 func TestMultiDocGeneric_Worker(t *testing.T) {
-	output := renderChartTemplate(t, "../../charts/generic", "templates/worker.yaml", "v1.12")
+	output := renderChartTemplateWithLookup(t, "../../charts/generic", "templates/worker.yaml", simpleNicLookup(), "v1.12")
 
 	// Multi-doc: machine section present
 	assertContains(t, output, "machine:")
@@ -1013,6 +1072,341 @@ func TestMultiDocGeneric_VlanOnBondTopology(t *testing.T) {
 	assertContains(t, result, "parent: bond0")
 	assertContains(t, result, "address: 10.0.0.50/24")
 	assertNotContains(t, result, "kind: LinkConfig")
+}
+
+// multiNicMultipleDefaultRoutesLookup emulates a node with two physical NICs,
+// each carrying a default route. eth0 is in `table=main`, eth1 is in a non-main
+// table (e.g. an alternate routing table) and a third interface has a main-table
+// route that should be ignored once the first match is taken. Used to verify
+// `default_link_name_by_gateway` (#108) returns a single deterministic value
+// rather than concatenating link names from every matching route.
+func multiNicMultipleDefaultRoutesLookup() func(string, string, string) (map[string]any, error) {
+	eth0 := map[string]any{
+		"metadata": map[string]any{"id": "eth0"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"hardwareAddr": "aa:bb:cc:dd:ee:00",
+			"busPath":      "pci-0000:00:1f.0",
+		},
+	}
+	eth1 := map[string]any{
+		"metadata": map[string]any{"id": "eth1"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"hardwareAddr": "aa:bb:cc:dd:ee:01",
+			"busPath":      "pci-0000:00:1f.1",
+		},
+	}
+	eth2 := map[string]any{
+		"metadata": map[string]any{"id": "eth2"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"hardwareAddr": "aa:bb:cc:dd:ee:02",
+			"busPath":      "pci-0000:00:1f.2",
+		},
+	}
+	routesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "10.99.0.1",
+					"outLinkName": "eth1",
+					"family":      "inet4",
+					"table":       "private",
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "192.168.1.1",
+					"outLinkName": "eth0",
+					"family":      "inet4",
+					"table":       "main",
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "192.168.2.1",
+					"outLinkName": "eth2",
+					"family":      "inet4",
+					"table":       "main",
+				},
+			},
+		},
+	}
+	linksList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      []any{eth0, eth1, eth2},
+	}
+	addressesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{
+				"spec": map[string]any{
+					"linkName": "eth0",
+					"address":  "192.168.1.10/24",
+					"family":   "inet4",
+					"scope":    "global",
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"linkName": "eth1",
+					"address":  "10.99.0.5/24",
+					"family":   "inet4",
+					"scope":    "global",
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"linkName": "eth2",
+					"address":  "192.168.2.10/24",
+					"family":   "inet4",
+					"scope":    "global",
+				},
+			},
+		},
+	}
+	return func(resource, _, id string) (map[string]any, error) {
+		switch resource {
+		case "routes":
+			return routesList, nil
+		case "links":
+			switch id {
+			case "eth0":
+				return eth0, nil
+			case "eth1":
+				return eth1, nil
+			case "eth2":
+				return eth2, nil
+			case "":
+				return linksList, nil
+			}
+			return map[string]any{}, nil
+		case "addresses":
+			return addressesList, nil
+		}
+		return map[string]any{}, nil
+	}
+}
+
+// TestDefaultLinkByGatewayHelpers_MultiNIC is a regression test for #108.
+// When a node has multiple default routes (typical for DHCP on multi-NIC
+// machines), the helpers historically iterated all matches and concatenated
+// the outputs (e.g. `eth0eth1eth2`) and didn't filter by `table=main`.
+// After the fix the helpers must:
+//   - filter routes by table=main
+//   - return exactly one value (the first matching route)
+func TestDefaultLinkByGatewayHelpers_MultiNIC(t *testing.T) {
+	const tmpl = `link={{ include "talm.discovered.default_link_name_by_gateway" . }}
+mac={{ include "talm.discovered.default_link_address_by_gateway" . }}
+`
+	chartRoot := createTestChart(t, "tc", "out.yaml", tmpl)
+
+	// Vendor the talm helpers into the test chart so the include resolves.
+	helpersSrc, err := os.ReadFile("../../charts/talm/templates/_helpers.tpl")
+	if err != nil {
+		t.Fatalf("read helpers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartRoot, "templates", "_helpers.tpl"), helpersSrc, 0o644); err != nil {
+		t.Fatalf("write vendored helpers: %v", err)
+	}
+
+	output := renderChartTemplateWithLookup(t, chartRoot, "templates/out.yaml", multiNicMultipleDefaultRoutesLookup())
+
+	assertContains(t, output, "link=eth0\n")
+	assertContains(t, output, "mac=aa:bb:cc:dd:ee:00\n")
+	assertNotContains(t, output, "eth1")
+	assertNotContains(t, output, "eth2")
+}
+
+// secondaryNicLookup emulates a node with two physical NICs (eth0 primary
+// with a default route, eth1 storage with a static subnet route and no
+// default) plus a bond master link. Used to exercise the multi-NIC discovery
+// helpers added for #125.
+func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
+	eth0 := map[string]any{
+		"metadata": map[string]any{"id": "eth0"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"hardwareAddr": "aa:bb:cc:dd:ee:00",
+			"busPath":      "pci-0000:00:1f.0",
+		},
+	}
+	eth1 := map[string]any{
+		"metadata": map[string]any{"id": "eth1"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"hardwareAddr": "aa:bb:cc:dd:ee:01",
+			"busPath":      "pci-0000:00:1f.1",
+		},
+	}
+	bond0 := map[string]any{
+		"metadata": map[string]any{"id": "bond0"},
+		"spec": map[string]any{
+			"kind":         "bond",
+			"hardwareAddr": "aa:bb:cc:dd:ee:ff",
+		},
+	}
+	routesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "192.168.1.1",
+					"outLinkName": "eth0",
+					"family":      "inet4",
+					"table":       "main",
+					"priority":    100,
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "10.0.0.0/24",
+					"gateway":     "",
+					"outLinkName": "eth1",
+					"family":      "inet4",
+					"table":       "main",
+					"priority":    100,
+				},
+			},
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "10.10.0.0/16",
+					"gateway":     "10.0.0.254",
+					"outLinkName": "eth1",
+					"family":      "inet4",
+					"table":       "main",
+					"priority":    200,
+				},
+			},
+		},
+	}
+	linksList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      []any{eth0, eth1, bond0},
+	}
+	addressesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{"spec": map[string]any{"linkName": "eth0", "address": "192.168.1.10/24", "family": "inet4", "scope": "global"}},
+			map[string]any{"spec": map[string]any{"linkName": "eth1", "address": "10.0.0.5/24", "family": "inet4", "scope": "global"}},
+			map[string]any{"spec": map[string]any{"linkName": "lo", "address": "127.0.0.1/8", "family": "inet4", "scope": "host"}},
+		},
+	}
+	return func(resource, _, id string) (map[string]any, error) {
+		switch resource {
+		case "routes":
+			return routesList, nil
+		case "links":
+			switch id {
+			case "eth0":
+				return eth0, nil
+			case "eth1":
+				return eth1, nil
+			case "bond0":
+				return bond0, nil
+			case "":
+				return linksList, nil
+			}
+			return map[string]any{}, nil
+		case "addresses":
+			return addressesList, nil
+		}
+		return map[string]any{}, nil
+	}
+}
+
+// TestSecondaryNicHelpers covers the per-link helpers added for #125. They
+// expose every physical NIC (not just the primary one carrying the default
+// route) so user templates can configure secondary uplinks (e.g. storage
+// network on a control-plane).
+func TestSecondaryNicHelpers(t *testing.T) {
+	const tmpl = `physical={{ include "talm.discovered.physical_links" . }}
+configurable={{ include "talm.discovered.configurable_links" . }}
+addr_eth0={{ include "talm.discovered.addresses_by_link" "eth0" }}
+addr_eth1={{ include "talm.discovered.addresses_by_link" "eth1" }}
+gw_eth0={{ include "talm.discovered.gateway_by_link" "eth0" }}
+gw_eth1={{ include "talm.discovered.gateway_by_link" "eth1" }}
+routes_eth1={{ include "talm.discovered.routes_by_link" "eth1" }}
+mac_eth1={{ include "talm.discovered.mac_by_link" "eth1" }}
+bus_eth1={{ include "talm.discovered.bus_by_link" "eth1" }}
+selector_eth1=
+{{ include "talm.discovered.link_selector_by_name" "eth1" }}
+`
+	chartRoot := createTestChart(t, "tc", "out.yaml", tmpl)
+	helpersSrc, err := os.ReadFile("../../charts/talm/templates/_helpers.tpl")
+	if err != nil {
+		t.Fatalf("read helpers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartRoot, "templates", "_helpers.tpl"), helpersSrc, 0o644); err != nil {
+		t.Fatalf("write vendored helpers: %v", err)
+	}
+
+	output := renderChartTemplateWithLookup(t, chartRoot, "templates/out.yaml", secondaryNicLookup())
+
+	assertContains(t, output, `physical=["eth0","eth1"]`)
+	// configurable_links must include the bond master too.
+	assertContains(t, output, `configurable=["eth0","eth1","bond0"]`)
+	assertContains(t, output, `addr_eth0=["192.168.1.10/24"]`)
+	assertContains(t, output, `addr_eth1=["10.0.0.5/24"]`)
+	assertContains(t, output, "gw_eth0=192.168.1.1")
+	// Storage NIC has no default route.
+	assertContains(t, output, "gw_eth1=\n")
+	// Static routes are exposed; default route is excluded.
+	assertContains(t, output, `"dst":"10.0.0.0/24"`)
+	assertContains(t, output, `"dst":"10.10.0.0/16"`)
+	assertContains(t, output, `"gateway":"10.0.0.254"`)
+	assertNotContains(t, output, `"dst":""`)
+	assertContains(t, output, "mac_eth1=aa:bb:cc:dd:ee:01")
+	assertContains(t, output, "bus_eth1=pci-0000:00:1f.1")
+	assertContains(t, output, "busPath: pci-0000:00:1f.1")
+}
+
+// TestNetworkMultidoc_NoDiscovery is a regression test for #58. When discovery
+// returns no default route (offline render, isolated node, custom networking),
+// the multidoc cozystack template must NOT emit a LinkConfig/BondConfig/
+// VLANConfig/Layer2VIPConfig with empty `name:` — Talos v1.12 rejects such
+// documents with `[networking.os.device.interface] required`.
+func TestNetworkMultidoc_NoDiscovery(t *testing.T) {
+	output := renderChartTemplate(t, "../../charts/cozystack", "templates/controlplane.yaml", "v1.12")
+
+	assertNotContains(t, output, "kind: LinkConfig")
+	assertNotContains(t, output, "kind: BondConfig")
+	assertNotContains(t, output, "kind: VLANConfig")
+	assertNotContains(t, output, "kind: Layer2VIPConfig")
+	// HostnameConfig/ResolverConfig still emit (independent of link discovery).
+	assertContains(t, output, "kind: HostnameConfig")
+	assertContains(t, output, "kind: ResolverConfig")
+}
+
+// TestNetworkLegacy_NoDiscovery is a regression test for #58 covering the
+// legacy (Talos < v1.12) path. The `interfaces:` key was unconditionally
+// emitted, producing either an empty list or a `- interface:` block with an
+// empty interface name when discovery found no default route. Either form
+// breaks Talos validation. After the fix, the template must skip both
+// `interfaces:` and the per-interface block entirely.
+func TestNetworkLegacy_NoDiscovery(t *testing.T) {
+	output := renderChartTemplate(t, "../../charts/cozystack", "templates/controlplane.yaml", "v1.11")
+
+	// `    interfaces:` (the YAML key) must not appear; the helper-emitted
+	// `# -- Discovered interfaces:` comment is fine and intentional.
+	assertNotContains(t, output, "    interfaces:")
+	assertNotContains(t, output, "- interface: \n")
+	// Hostname / nameservers should still be rendered — they are independent
+	// of link discovery.
+	assertContains(t, output, "hostname:")
+	assertContains(t, output, "nameservers:")
 }
 
 // TestMergeFileAsPatch pins the contract for the apply-side overlay of a

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -1206,6 +1206,7 @@ func multiNicMultipleDefaultRoutesLookup() func(string, string, string) (map[str
 func TestDefaultLinkByGatewayHelpers_MultiNIC(t *testing.T) {
 	const tmpl = `link={{ include "talm.discovered.default_link_name_by_gateway" . }}
 mac={{ include "talm.discovered.default_link_address_by_gateway" . }}
+bus={{ include "talm.discovered.default_link_bus_by_gateway" . }}
 `
 	chartRoot := createTestChart(t, "tc", "out.yaml", tmpl)
 
@@ -1222,6 +1223,10 @@ mac={{ include "talm.discovered.default_link_address_by_gateway" . }}
 
 	assertContains(t, output, "link=eth0\n")
 	assertContains(t, output, "mac=aa:bb:cc:dd:ee:00\n")
+	// default_link_bus_by_gateway must return the busPath, not the MAC.
+	// Long-standing copy-paste bug from the address helper: see commit log.
+	assertContains(t, output, "bus=pci-0000:00:1f.0\n")
+	assertNotContains(t, output, "bus=aa:bb:cc:dd:ee:00")
 	assertNotContains(t, output, "eth1")
 	assertNotContains(t, output, "eth2")
 }
@@ -1301,13 +1306,25 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 					"priority":    200,
 				},
 			},
-			// Route with several fields absent — exercises the default ""
-			// guard in routes_by_link so consumers never see "<nil>".
+			// Route with several fields absent — exercises the kindIs
+			// "invalid" guard in routes_by_link so consumers never see "<nil>".
 			map[string]any{
 				"spec": map[string]any{
 					"dst":         "172.16.0.0/12",
 					"outLinkName": "eth1",
 					"table":       "main",
+				},
+			},
+			// Route with priority: 0 — int zero must round-trip through
+			// printf "%v" (the older `default ""` guard collapsed it to "").
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "203.0.113.0/24",
+					"gateway":     "10.0.0.1",
+					"outLinkName": "eth1",
+					"family":      "inet4",
+					"table":       "main",
+					"priority":    0,
 				},
 			},
 		},
@@ -1326,6 +1343,10 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 			// IPv6 link-local on a configurable link — addresses_by_link must
 			// filter scope=link out so callers never configure fe80::/64.
 			map[string]any{"spec": map[string]any{"linkName": "eth1", "address": "fe80::aa:bbff:fecc:dd01/64", "family": "inet6", "scope": "link"}},
+			// Address with no scope set at all — must also be filtered out
+			// (defensive: real Talos always emits scope, but missing-field
+			// safety matters for user mocks and future API changes).
+			map[string]any{"spec": map[string]any{"linkName": "eth1", "address": "10.99.99.99/32", "family": "inet4"}},
 			map[string]any{"spec": map[string]any{"linkName": "lo", "address": "127.0.0.1/8", "family": "inet4", "scope": "host"}},
 		},
 	}
@@ -1357,8 +1378,8 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 // route) so user templates can configure secondary uplinks (e.g. storage
 // network on a control-plane).
 func TestSecondaryNicHelpers(t *testing.T) {
-	const tmpl = `physical={{ include "talm.discovered.physical_links" . }}
-configurable={{ include "talm.discovered.configurable_links" . }}
+	const tmpl = `physical={{ include "talm.discovered.physical_link_names" . }}
+configurable={{ include "talm.discovered.configurable_link_names" . }}
 addr_eth0={{ include "talm.discovered.addresses_by_link" "eth0" }}
 addr_eth1={{ include "talm.discovered.addresses_by_link" "eth1" }}
 gw_eth0={{ include "talm.discovered.gateway_by_link" "eth0" }}
@@ -1366,6 +1387,8 @@ gw_eth1={{ include "talm.discovered.gateway_by_link" "eth1" }}
 routes_eth1={{ include "talm.discovered.routes_by_link" "eth1" }}
 mac_eth1={{ include "talm.discovered.mac_by_link" "eth1" }}
 bus_eth1={{ include "talm.discovered.bus_by_link" "eth1" }}
+mac_unknown={{ include "talm.discovered.mac_by_link" "doesnotexist" }}
+bus_unknown={{ include "talm.discovered.bus_by_link" "doesnotexist" }}
 selector_eth1=
 {{ include "talm.discovered.link_selector_by_name" "eth1" }}
 `
@@ -1381,12 +1404,15 @@ selector_eth1=
 	output := renderChartTemplateWithLookup(t, chartRoot, "templates/out.yaml", secondaryNicLookup())
 
 	assertContains(t, output, `physical=["eth0","eth1"]`)
-	// configurable_links must include the bond master too.
+	// configurable_link_names must include the bond master too.
 	assertContains(t, output, `configurable=["eth0","eth1","bond0"]`)
 	assertContains(t, output, `addr_eth0=["192.168.1.10/24"]`)
-	// IPv6 link-local (scope=link) on eth1 must be filtered out.
+	// eth1 has 4 raw addresses but only the global one survives the filter:
+	// fe80::/64 (scope=link), 10.99.99.99/32 (no scope), 127.0.0.1/8
+	// (scope=host on lo, different link) — all rejected.
 	assertContains(t, output, `addr_eth1=["10.0.0.5/24"]`)
 	assertNotContains(t, output, "fe80::aa:bbff:fecc:dd01")
+	assertNotContains(t, output, "10.99.99.99")
 	// gateway_by_link returns IPv4 even when an IPv6 default route is also
 	// present on the same link.
 	assertContains(t, output, "gw_eth0=192.168.1.1")
@@ -1397,14 +1423,22 @@ selector_eth1=
 	assertContains(t, output, `"dst":"10.0.0.0/24"`)
 	assertContains(t, output, `"dst":"10.10.0.0/16"`)
 	assertContains(t, output, `"dst":"172.16.0.0/12"`)
+	assertContains(t, output, `"dst":"203.0.113.0/24"`)
 	assertContains(t, output, `"gateway":"10.0.0.254"`)
 	assertNotContains(t, output, `"dst":""`)
+	// priority: 0 must round-trip as "0", not collapse to "" via sprig
+	// `default ""`.
+	assertContains(t, output, `"priority":"0"`)
 	// Missing route fields must render as empty strings, never "<nil>" or
 	// HTML-escaped "\u003cnil\u003e".
 	assertNotContains(t, output, "<nil>")
 	assertNotContains(t, output, `\u003cnil\u003e`)
 	assertContains(t, output, "mac_eth1=aa:bb:cc:dd:ee:01")
 	assertContains(t, output, "bus_eth1=pci-0000:00:1f.1")
+	// Unknown link must yield empty MAC/busPath even when the lookup mock
+	// returns an empty map (real Helm returns nil; defensive on both).
+	assertContains(t, output, "mac_unknown=\n")
+	assertContains(t, output, "bus_unknown=\n")
 	assertContains(t, output, "busPath: pci-0000:00:1f.1")
 }
 

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -1258,6 +1258,19 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 		"apiVersion": "v1",
 		"kind":       "List",
 		"items": []any{
+			// IPv6 default route ordered first so a missing family filter in
+			// gateway_by_link would return fe80::1 instead of the IPv4
+			// gateway. Required for the no-IPv4-family-filter regression.
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "fe80::1",
+					"outLinkName": "eth0",
+					"family":      "inet6",
+					"table":       "main",
+					"priority":    1024,
+				},
+			},
 			map[string]any{
 				"spec": map[string]any{
 					"dst":         "",
@@ -1288,6 +1301,15 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 					"priority":    200,
 				},
 			},
+			// Route with several fields absent — exercises the default ""
+			// guard in routes_by_link so consumers never see "<nil>".
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "172.16.0.0/12",
+					"outLinkName": "eth1",
+					"table":       "main",
+				},
+			},
 		},
 	}
 	linksList := map[string]any{
@@ -1301,6 +1323,9 @@ func secondaryNicLookup() func(string, string, string) (map[string]any, error) {
 		"items": []any{
 			map[string]any{"spec": map[string]any{"linkName": "eth0", "address": "192.168.1.10/24", "family": "inet4", "scope": "global"}},
 			map[string]any{"spec": map[string]any{"linkName": "eth1", "address": "10.0.0.5/24", "family": "inet4", "scope": "global"}},
+			// IPv6 link-local on a configurable link — addresses_by_link must
+			// filter scope=link out so callers never configure fe80::/64.
+			map[string]any{"spec": map[string]any{"linkName": "eth1", "address": "fe80::aa:bbff:fecc:dd01/64", "family": "inet6", "scope": "link"}},
 			map[string]any{"spec": map[string]any{"linkName": "lo", "address": "127.0.0.1/8", "family": "inet4", "scope": "host"}},
 		},
 	}
@@ -1359,15 +1384,25 @@ selector_eth1=
 	// configurable_links must include the bond master too.
 	assertContains(t, output, `configurable=["eth0","eth1","bond0"]`)
 	assertContains(t, output, `addr_eth0=["192.168.1.10/24"]`)
+	// IPv6 link-local (scope=link) on eth1 must be filtered out.
 	assertContains(t, output, `addr_eth1=["10.0.0.5/24"]`)
+	assertNotContains(t, output, "fe80::aa:bbff:fecc:dd01")
+	// gateway_by_link returns IPv4 even when an IPv6 default route is also
+	// present on the same link.
 	assertContains(t, output, "gw_eth0=192.168.1.1")
+	assertNotContains(t, output, "gw_eth0=fe80::1")
 	// Storage NIC has no default route.
 	assertContains(t, output, "gw_eth1=\n")
 	// Static routes are exposed; default route is excluded.
 	assertContains(t, output, `"dst":"10.0.0.0/24"`)
 	assertContains(t, output, `"dst":"10.10.0.0/16"`)
+	assertContains(t, output, `"dst":"172.16.0.0/12"`)
 	assertContains(t, output, `"gateway":"10.0.0.254"`)
 	assertNotContains(t, output, `"dst":""`)
+	// Missing route fields must render as empty strings, never "<nil>" or
+	// HTML-escaped "\u003cnil\u003e".
+	assertNotContains(t, output, "<nil>")
+	assertNotContains(t, output, `\u003cnil\u003e`)
 	assertContains(t, output, "mac_eth1=aa:bb:cc:dd:ee:01")
 	assertContains(t, output, "bus_eth1=pci-0000:00:1f.1")
 	assertContains(t, output, "busPath: pci-0000:00:1f.1")


### PR DESCRIPTION
## Summary

Three independent fixes/improvements in the discovery helpers and network templates, all touching the same area:

1. **`default_*_by_gateway` helpers now return a single deterministic value.** On multi-NIC nodes with several default routes (typical with DHCP), the helpers iterated every matching route and concatenated the outputs — `eth0eth1` for `default_link_name_by_gateway`, two MACs glued together for the address variant, two `busPath: ...` YAML fragments for the selector. Downstream templates used the joined string as the interface name, so Talos either rejected the config or applied it to the wrong NIC. They now filter by `table=main` and break after the first match. Also fixes a long-standing copy-paste bug in `default_link_bus_by_gateway`, which was returning the link's MAC address instead of its `busPath`.

2. **Empty interface emission removed from cozystack/generic templates.** When discovery returned no default route (offline render, isolated node, custom networking), the templates emitted Talos documents with empty names: `LinkConfig`/`BondConfig`/`VLANConfig`/`Layer2VIPConfig` with empty `name:` (multidoc), or `interfaces:` followed by `- interface:` with an empty value (legacy). Talos v1.12 rejects the multidoc form; the legacy form produced invalid YAML in some environments. The per-interface documents are now skipped when no default link is discovered.

3. **New per-link discovery helpers for multi-NIC templates.** The existing `default_*_by_gateway` family exposes only the primary link. Templates for nodes with secondary NICs (storage uplink on a control-plane, second public link, etc.) had no way to enumerate every NIC or read addresses/gateway/MAC by name. Adds `physical_link_names`, `configurable_link_names`, `addresses_by_link`, `gateway_by_link` (IPv4 only by convention), `routes_by_link`, `mac_by_link`, `bus_by_link`, `link_selector_by_name`. Default cozystack/generic templates are unchanged; the new helpers are building blocks for user templates.

## Verification

- New unit tests cover all three changes: `TestDefaultLinkByGatewayHelpers_MultiNIC`, `TestNetworkMultidoc_NoDiscovery` / `TestNetworkLegacy_NoDiscovery`, `TestSecondaryNicHelpers`. The multi-NIC test fixture deliberately mixes routes across `table=main` and a private table to exercise both the table filter and the early break; the secondary-NIC fixture orders an IPv6 default route ahead of the IPv4 one to catch a missing family filter; the route fixture includes both an entry with absent fields and one with `priority: 0`.
- Existing offline tests that previously asserted broken-empty `LinkConfig` output now use `simpleNicLookup` so they continue to validate the populated render path. `TestMultiDocCozystack_BondTopology` and `_VlanOnBondTopology` are byte-for-byte identical and still pass.
- `golangci-lint run` is clean.

## Closes

- Closes #58
- Closes #108
- Refs #125 — adds the helpers; cozystack default templates intentionally unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-NIC network helper utilities for enhanced network configuration discovery and management.

* **Bug Fixes**
  * Improved network discovery to accurately select the correct network interface when multiple default routes exist.
  * Enhanced network interface configuration rendering to gracefully handle scenarios where network discovery provides no data.

* **Tests**
  * Added comprehensive regression tests for multi-NIC and network discovery scenarios to ensure robust network configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->