### PR TITLE
fix(windows): CI matrix, zip archives, and NTFS ACL for sensitive files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,9 @@ archives:
       {{- if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ curl -sSL https://github.com/cozystack/talm/raw/refs/heads/main/hack/install.sh 
 
 Windows is supported. Download the `talm-windows-*.zip` archive from the
 [releases page](https://github.com/cozystack/talm/releases/latest) and
-extract `talm.exe`. Template paths passed to flags like `-t` may use
-either `\` or `/` separators (`-t templates\controlplane.yaml` and
-`-t templates/controlplane.yaml` are equivalent).
+extract `talm.exe`. On Windows, template paths passed to the `-t` /
+`--template` flag accept either `\` or `/` separators, so
+`-t templates\controlplane.yaml` and `-t templates/controlplane.yaml`
+are equivalent. Other path flags (`--talosconfig`, `-f` / `--file`)
+are delegated to the underlying OS file loader and follow standard
+Windows path rules.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Or use simple script to install it:
 curl -sSL https://github.com/cozystack/talm/raw/refs/heads/main/hack/install.sh | sh -s
 ```
 
+### Windows
+
+Windows is supported. Download the `talm-windows-*.zip` archive from the
+[releases page](https://github.com/cozystack/talm/releases/latest) and
+extract `talm.exe`. Template paths passed to flags like `-t` may use
+either `\` or `/` separators (`-t templates\controlplane.yaml` and
+`-t templates/controlplane.yaml` are equivalent).
+
 ## Getting Started
 
 Create new project

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -26,6 +26,8 @@ import (
 
 	"filippo.io/age"
 	"gopkg.in/yaml.v3"
+
+	"github.com/cozystack/talm/pkg/secureperm"
 )
 
 const (
@@ -65,7 +67,7 @@ func GenerateKey(rootDir string) (*age.X25519Identity, bool, error) {
 	keyData += fmt.Sprintf("# public key: %s\n", publicKey)
 	keyData += identity.String() + "\n"
 
-	if err := os.WriteFile(keyFile, []byte(keyData), 0o600); err != nil {
+	if err := secureperm.WriteFile(keyFile, []byte(keyData)); err != nil {
 		return nil, false, fmt.Errorf("failed to write key file: %w", err)
 	}
 
@@ -263,7 +265,7 @@ func DecryptSecretsFile(rootDir string) error {
 	}
 
 	// Write decrypted file with secure permissions
-	if err := os.WriteFile(secretsFile, decryptedData, 0o600); err != nil {
+	if err := secureperm.WriteFile(secretsFile, decryptedData); err != nil {
 		return fmt.Errorf("failed to write decrypted file: %w", err)
 	}
 
@@ -652,7 +654,7 @@ func DecryptYAMLFile(rootDir, encryptedFile, plainFile string) error {
 	}
 
 	// Write decrypted file with secure permissions
-	if err := os.WriteFile(plainFilePath, decryptedData, 0o600); err != nil {
+	if err := secureperm.WriteFile(plainFilePath, decryptedData); err != nil {
 		return fmt.Errorf("failed to write decrypted file: %w", err)
 	}
 

--- a/pkg/age/age_unix_test.go
+++ b/pkg/age/age_unix_test.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package age_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cozystack/talm/pkg/age"
+)
+
+// TestGenerateKey_Mode0600_Unix pins that the age private key file
+// is written with owner-only permissions. The file contains the raw
+// X25519 private key that protects every encrypted secret in the
+// project — if a future refactor ever swaps secureperm.WriteFile
+// back to os.WriteFile with a different mode, this test fails.
+func TestGenerateKey_Mode0600_Unix(t *testing.T) {
+	dir := t.TempDir()
+
+	identity, created, err := age.GenerateKey(dir)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if !created {
+		t.Fatal("expected GenerateKey to create a new key in an empty dir")
+	}
+	if identity == nil {
+		t.Fatal("nil identity from GenerateKey")
+	}
+
+	keyPath := filepath.Join(dir, "talm.key")
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("talm.key mode = %o, want 0600", got)
+	}
+}

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -420,6 +420,15 @@ func wrapWithNodeContext(f func(ctx context.Context, c *client.Client) error) fu
 	}
 }
 
+// isOutsideRoot reports whether a cleaned relative path escapes the
+// project root. A HasPrefix(".." ) test would misclassify sibling
+// directories whose first path element merely starts with "..", such
+// as "..templates/controlplane.yaml"; we match a full path element
+// instead.
+func isOutsideRoot(relPath string) bool {
+	return relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator))
+}
+
 // resolveTemplatePaths resolves template file paths relative to the project root,
 // normalizing them for the Helm engine (forward slashes).
 // Relative paths from the modeline are resolved against rootDir, not CWD.
@@ -461,7 +470,7 @@ func resolveTemplatePaths(templates []string, rootDir string) []string {
 			continue
 		}
 		relPath = filepath.Clean(relPath)
-		if strings.HasPrefix(relPath, "..") {
+		if isOutsideRoot(relPath) {
 			// Path goes outside project root — use original path as-is
 			resolved[i] = engine.NormalizeTemplatePath(templatePath)
 			continue

--- a/pkg/commands/apply_test.go
+++ b/pkg/commands/apply_test.go
@@ -115,6 +115,12 @@ func TestResolveTemplatePaths(t *testing.T) {
 		t.Fatalf("failed to create templates dir: %v", err)
 	}
 
+	// Build a platform-portable absolute path outside tmpRoot.
+	// filepath.VolumeName is "" on POSIX (yielding e.g. "/other/...") and
+	// "C:" on Windows (yielding "C:\other\..."). Both are absolute and
+	// definitely outside tmpRoot (which lives under the user temp dir).
+	absOutside := filepath.Join(filepath.VolumeName(tmpRoot), string(filepath.Separator), "other", "project", "templates", "controlplane.yaml")
+
 	tests := []struct {
 		name      string
 		templates []string
@@ -146,10 +152,14 @@ func TestResolveTemplatePaths(t *testing.T) {
 			want:      []string{"templates/controlplane.yaml"},
 		},
 		{
+			// Constructed to be absolute on both POSIX and Windows so the
+			// filepath.IsAbs branch is exercised on both CI runners. The
+			// resolver normalizes outside-root paths via filepath.ToSlash,
+			// so the expected output is the forward-slash form.
 			name:      "path outside rootDir is kept as-is",
-			templates: []string{"/other/project/templates/controlplane.yaml"},
+			templates: []string{absOutside},
 			rootDir:   tmpRoot,
-			want:      []string{"/other/project/templates/controlplane.yaml"},
+			want:      []string{filepath.ToSlash(absOutside)},
 		},
 	}
 

--- a/pkg/commands/apply_test.go
+++ b/pkg/commands/apply_test.go
@@ -114,6 +114,12 @@ func TestResolveTemplatePaths(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(tmpRoot, "templates"), 0o755); err != nil {
 		t.Fatalf("failed to create templates dir: %v", err)
 	}
+	// A sibling directory whose name literally starts with "..". A naive
+	// HasPrefix(relPath, "..") check would misclassify it as outside-root;
+	// the resolver must treat ".." as a full path element, not a prefix.
+	if err := os.MkdirAll(filepath.Join(tmpRoot, "..templates"), 0o755); err != nil {
+		t.Fatalf("failed to create ..templates dir: %v", err)
+	}
 
 	// Build a platform-portable absolute path outside tmpRoot.
 	// filepath.VolumeName is "" on POSIX (yielding e.g. "/other/...") and
@@ -160,6 +166,15 @@ func TestResolveTemplatePaths(t *testing.T) {
 			templates: []string{absOutside},
 			rootDir:   tmpRoot,
 			want:      []string{filepath.ToSlash(absOutside)},
+		},
+		{
+			// Directory name literally starting with "..". If the
+			// outside-root check used HasPrefix("..") it would wrongly
+			// drop this path back to the original input.
+			name:      "sibling dir whose name starts with .. is inside rootDir",
+			templates: []string{"..templates/controlplane.yaml"},
+			rootDir:   tmpRoot,
+			want:      []string{"..templates/controlplane.yaml"},
 		},
 	}
 

--- a/pkg/commands/apply_test.go
+++ b/pkg/commands/apply_test.go
@@ -740,3 +740,33 @@ machine:
 	// itself. The modeline round-trip tests in pkg/modeline surface a
 	// regression that would wire MergeFileAsPatch into generateOutput.
 }
+
+// TestIsOutsideRoot pins the contract that distinguishes a path that
+// truly escapes the project root (".." or a first element of "..")
+// from a path whose first element merely *starts* with ".." but is
+// itself a valid sibling-directory name (e.g. "..templates"). The
+// distinction matters wherever a caller routes inside-root paths
+// differently from outside-root ones; a HasPrefix("..") test
+// silently misclassifies the latter as outside-root.
+func TestIsOutsideRoot(t *testing.T) {
+	cases := []struct {
+		relPath string
+		want    bool
+	}{
+		{"..", true},
+		{".." + string(filepath.Separator) + "foo", true},
+		{".." + string(filepath.Separator) + "foo" + string(filepath.Separator) + "bar", true},
+		{"..foo", false},
+		{"..foo" + string(filepath.Separator) + "bar", false},
+		{"..templates" + string(filepath.Separator) + "controlplane.yaml", false},
+		{"..mykube", false},
+		{"foo", false},
+		{"foo" + string(filepath.Separator) + "..bar", false},
+		{".", false},
+	}
+	for _, c := range cases {
+		if got := isOutsideRoot(c.relPath); got != c.want {
+			t.Errorf("isOutsideRoot(%q) = %v, want %v", c.relPath, got, c.want)
+		}
+	}
+}

--- a/pkg/commands/apply_windows_test.go
+++ b/pkg/commands/apply_windows_test.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -75,21 +76,22 @@ func TestResolveTemplatePaths_BackslashInput(t *testing.T) {
 }
 
 // TestResolveTemplatePaths_OutsideRoot_Backslash asserts that a
-// backslash path that resolves outside rootDir is still normalized to
-// forward slashes (the engine map keys never contain backslashes, even
-// for paths that the caller declined to resolve).
+// backslash path resolving outside rootDir still emerges without any
+// backslashes — the helm engine only looks up templates by forward-
+// slash map keys, so regardless of which internal branch the function
+// takes (Rel-success, Rel-failure, prefix-checks), the result must be
+// backslash-free. Constructing `outside` via filepath.Join on rootDir
+// keeps the test on the same drive as t.TempDir() and works on any
+// GitHub Actions runner image.
 func TestResolveTemplatePaths_OutsideRoot_Backslash(t *testing.T) {
 	rootDir := t.TempDir()
-	// Absolute Windows path that is guaranteed not under rootDir.
-	outside := `C:\elsewhere\templates\foo.yaml`
+	outside := filepath.Join(rootDir, "..", "..", "..", "elsewhere", "templates", "foo.yaml")
 
 	got := resolveTemplatePaths([]string{outside}, rootDir)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(got))
 	}
-	// The function returns the original path on "outside" — but still
-	// normalized for the helm engine.
-	if want := "C:/elsewhere/templates/foo.yaml"; got[0] != want {
-		t.Errorf("outside-root normalization: got %q, want %q", got[0], want)
+	if strings.ContainsRune(got[0], '\\') {
+		t.Errorf("result still contains backslash: %q", got[0])
 	}
 }

--- a/pkg/commands/apply_windows_test.go
+++ b/pkg/commands/apply_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveTemplatePaths_BackslashInput is the regression guard for
+// issue #11: users running `talm apply` from PowerShell pass template
+// arguments with backslash separators (e.g. "templates\worker.yaml").
+// resolveTemplatePaths must normalize these to forward slashes because
+// the downstream helm engine only looks up templates by forward-slash
+// map keys.
+func TestResolveTemplatePaths_BackslashInput(t *testing.T) {
+	rootDir := t.TempDir()
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "relative with backslash",
+			input: `templates\controlplane.yaml`,
+			want:  "templates/controlplane.yaml",
+		},
+		{
+			name:  "relative nested backslashes",
+			input: `templates\nested\worker.yaml`,
+			want:  "templates/nested/worker.yaml",
+		},
+		{
+			name:  "mixed separators",
+			input: `templates\nested/worker.yaml`,
+			want:  "templates/nested/worker.yaml",
+		},
+		{
+			name:  "absolute path inside root",
+			input: filepath.Join(absRoot, "templates", "controlplane.yaml"),
+			want:  "templates/controlplane.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTemplatePaths([]string{tt.input}, rootDir)
+			if len(got) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(got))
+			}
+			if got[0] != tt.want {
+				t.Errorf("resolveTemplatePaths(%q) = %q, want %q", tt.input, got[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveTemplatePaths_OutsideRoot_Backslash asserts that a
+// backslash path that resolves outside rootDir is still normalized to
+// forward slashes (the engine map keys never contain backslashes, even
+// for paths that the caller declined to resolve).
+func TestResolveTemplatePaths_OutsideRoot_Backslash(t *testing.T) {
+	rootDir := t.TempDir()
+	// Absolute Windows path that is guaranteed not under rootDir.
+	outside := `C:\elsewhere\templates\foo.yaml`
+
+	got := resolveTemplatePaths([]string{outside}, rootDir)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(got))
+	}
+	// The function returns the original path on "outside" — but still
+	// normalized for the helm engine.
+	if want := "C:/elsewhere/templates/foo.yaml"; got[0] != want {
+		t.Errorf("outside-root normalization: got %q, want %q", got[0], want)
+	}
+}

--- a/pkg/commands/apply_windows_test.go
+++ b/pkg/commands/apply_windows_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 )
 
-// TestResolveTemplatePaths_BackslashInput is the regression guard for
-// issue #11: users running `talm apply` from PowerShell pass template
-// arguments with backslash separators (e.g. "templates\worker.yaml").
-// resolveTemplatePaths must normalize these to forward slashes because
-// the downstream helm engine only looks up templates by forward-slash
-// map keys.
+// TestResolveTemplatePaths_BackslashInput pins that users running
+// `talm apply` from PowerShell with template arguments that use
+// backslash separators (e.g. "templates\worker.yaml") end up with
+// forward-slash paths. The downstream helm engine only looks up
+// templates by forward-slash map keys, so anything else fails with
+// "template not found".
 func TestResolveTemplatePaths_BackslashInput(t *testing.T) {
 	rootDir := t.TempDir()
 	absRoot, err := filepath.Abs(rootDir)

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -345,7 +345,7 @@ var initCmd = &cobra.Command{
 				return fmt.Errorf("failed to marshal config: %+v", err)
 			}
 
-			if err = writeToDestination(data, talosconfigFile, 0o600); err != nil {
+			if err = writeSecureToDestination(data, talosconfigFile); err != nil {
 				return err
 			}
 		}
@@ -459,7 +459,7 @@ func writeSecretsBundleToFile(bundle *secrets.Bundle) error {
 		return err
 	}
 
-	return writeToDestination(bundleBytes, secretsFile, 0o600)
+	return writeSecureToDestination(bundleBytes, secretsFile)
 }
 
 // readChartYamlPreset reads Chart.yaml and determines the preset name from dependencies
@@ -874,15 +874,29 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 		return fmt.Errorf("failed to create output dir: %w", err)
 	}
 
-	// Route owner-only writes through secureperm so Windows files get an
-	// NTFS DACL applied — os.WriteFile's mode argument is effectively
-	// ignored on Windows.
-	var err error
-	if permissions == 0o600 {
-		err = secureperm.WriteFile(destination, data)
-	} else {
-		err = os.WriteFile(destination, data, permissions)
+	err := os.WriteFile(destination, data, permissions)
+
+	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
+
+	return err
+}
+
+// writeSecureToDestination writes a secret (talosconfig, secrets.yaml,
+// talm.key) with owner-only permissions. On Windows the NTFS DACL is
+// installed via secureperm so os.WriteFile's ignored mode bits aren't
+// the only defense.
+func writeSecureToDestination(data []byte, destination string) error {
+	if err := validateFileExists(destination); err != nil {
+		return err
 	}
+
+	parentDir := filepath.Dir(destination)
+
+	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create output dir: %w", err)
+	}
+
+	err := secureperm.WriteFile(destination, data)
 
 	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -456,10 +456,8 @@ func writeSecretsBundleToFile(bundle *secrets.Bundle) error {
 	}
 
 	secretsFile := filepath.Join(Config.RootDir, "secrets.yaml")
-	if err = validateFileExists(secretsFile); err != nil {
-		return err
-	}
-
+	// validateFileExists is invoked inside writeSecureToDestination;
+	// no need to duplicate the --force / existing-file gate here.
 	return writeSecureToDestination(bundleBytes, secretsFile)
 }
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -895,7 +895,10 @@ func writeSecureToDestination(data []byte, destination string) error {
 
 	parentDir := filepath.Dir(destination)
 
-	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+	// Use 0o700 so any newly-created parent dir for secrets is owner-only
+	// even under a permissive umask. MkdirAll is a no-op when the dir
+	// already exists, so this does not override pre-existing dir perms.
+	if err := os.MkdirAll(parentDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create output dir: %w", err)
 	}
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cozystack/talm/pkg/age"
 	"github.com/cozystack/talm/pkg/generated"
+	"github.com/cozystack/talm/pkg/secureperm"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -873,7 +874,15 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 		return fmt.Errorf("failed to create output dir: %w", err)
 	}
 
-	err := os.WriteFile(destination, data, permissions)
+	// Route owner-only writes through secureperm so Windows files get an
+	// NTFS DACL applied — os.WriteFile's mode argument is effectively
+	// ignored on Windows.
+	var err error
+	if permissions == 0o600 {
+		err = secureperm.WriteFile(destination, data)
+	} else {
+		err = os.WriteFile(destination, data, permissions)
+	}
 
 	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -862,6 +863,10 @@ func handleTalosconfigEncryption(requireKeyForDecrypt bool) (bool, error) {
 	return keyWasCreated, nil
 }
 
+// createdSink is where "Created <path>" messages go after a successful
+// write. Swappable in tests to assert no message is emitted on failure.
+var createdSink io.Writer = os.Stderr
+
 func writeToDestination(data []byte, destination string, permissions os.FileMode) error {
 	if err := validateFileExists(destination); err != nil {
 		return err
@@ -875,9 +880,9 @@ func writeToDestination(data []byte, destination string, permissions os.FileMode
 	}
 
 	err := os.WriteFile(destination, data, permissions)
-
-	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
-
+	if err == nil {
+		_, _ = fmt.Fprintf(createdSink, "Created %s\n", destination)
+	}
 	return err
 }
 
@@ -897,8 +902,8 @@ func writeSecureToDestination(data []byte, destination string) error {
 	}
 
 	err := secureperm.WriteFile(destination, data)
-
-	fmt.Fprintf(os.Stderr, "Created %s\n", destination)
-
+	if err == nil {
+		_, _ = fmt.Fprintf(createdSink, "Created %s\n", destination)
+	}
 	return err
 }

--- a/pkg/commands/init_test.go
+++ b/pkg/commands/init_test.go
@@ -1,0 +1,105 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+// writeToDestinationSilentOnFailureCases asserts neither writeTo-
+// Destination nor writeSecureToDestination emits a misleading
+// "Created <path>" line when the underlying write fails. The failure
+// is induced by pointing destination at an existing directory, which
+// makes os.WriteFile (and therefore secureperm.WriteFile) fail.
+func TestWriteToDestination_SilentOnFailure(t *testing.T) {
+	forceOrig := initCmdFlags.force
+	sinkOrig := createdSink
+	t.Cleanup(func() {
+		initCmdFlags.force = forceOrig
+		createdSink = sinkOrig
+	})
+
+	initCmdFlags.force = true
+
+	cases := []struct {
+		name string
+		call func(data []byte, dest string) error
+	}{
+		{
+			name: "writeToDestination",
+			call: func(data []byte, dest string) error {
+				return writeToDestination(data, dest, 0o644)
+			},
+		},
+		{
+			name: "writeSecureToDestination",
+			call: func(data []byte, dest string) error {
+				return writeSecureToDestination(data, dest)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			createdSink = &buf
+
+			// Destination is an existing directory — the underlying write
+			// call fails without touching the filesystem content.
+			dir := t.TempDir()
+
+			err := tc.call([]byte("data"), dir)
+			if err == nil {
+				t.Fatal("expected error writing to directory, got nil")
+			}
+			if strings.Contains(buf.String(), "Created") {
+				t.Errorf("output contains 'Created' despite failure: %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestWriteToDestination_AnnouncesOnSuccess pins that the happy path
+// still prints "Created <path>" — i.e. the new err==nil guard didn't
+// accidentally silence the normal success message.
+func TestWriteToDestination_AnnouncesOnSuccess(t *testing.T) {
+	forceOrig := initCmdFlags.force
+	sinkOrig := createdSink
+	t.Cleanup(func() {
+		initCmdFlags.force = forceOrig
+		createdSink = sinkOrig
+	})
+
+	initCmdFlags.force = true
+
+	var buf bytes.Buffer
+	createdSink = &buf
+
+	dir := t.TempDir()
+	path := dir + "/ok.txt"
+
+	if err := writeToDestination([]byte("x"), path, 0o644); err != nil {
+		t.Fatalf("writeToDestination: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Created "+path) {
+		t.Errorf("expected 'Created %s' in output, got %q", path, buf.String())
+	}
+}
+
+// compile-time assert createdSink is writer-shaped.
+var _ io.Writer = (*bytes.Buffer)(nil)

--- a/pkg/commands/init_test.go
+++ b/pkg/commands/init_test.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -104,3 +105,44 @@ func TestWriteToDestination_AnnouncesOnSuccess(t *testing.T) {
 
 // compile-time assert createdSink is writer-shaped.
 var _ io.Writer = (*bytes.Buffer)(nil)
+
+// TestWriteSecretsBundleToFile_StillRefusesOverwrite pins that
+// writeSecretsBundleToFile still honors the --force gate after the
+// redundant validateFileExists call was dropped — the gate now lives
+// only inside writeSecureToDestination, and this test would fail if
+// that inner check were ever removed too.
+func TestWriteSecretsBundleToFile_StillRefusesOverwrite(t *testing.T) {
+	forceOrig := initCmdFlags.force
+	rootOrig := Config.RootDir
+	t.Cleanup(func() {
+		initCmdFlags.force = forceOrig
+		Config.RootDir = rootOrig
+	})
+
+	dir := t.TempDir()
+	Config.RootDir = dir
+	initCmdFlags.force = false
+
+	// Seed a pre-existing secrets.yaml.
+	existing := filepath.Join(dir, "secrets.yaml")
+	if err := os.WriteFile(existing, []byte("preserve-me"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := writeSecretsBundleToFile(nil)
+	if err == nil {
+		t.Fatal("expected error refusing to overwrite existing secrets.yaml")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention existing-file gate, got: %v", err)
+	}
+
+	// Original content must be intact.
+	got, readErr := os.ReadFile(existing)
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if string(got) != "preserve-me" {
+		t.Errorf("original content changed: %q", got)
+	}
+}

--- a/pkg/commands/init_test.go
+++ b/pkg/commands/init_test.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"bytes"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -91,7 +92,7 @@ func TestWriteToDestination_AnnouncesOnSuccess(t *testing.T) {
 	createdSink = &buf
 
 	dir := t.TempDir()
-	path := dir + "/ok.txt"
+	path := filepath.Join(dir, "ok.txt")
 
 	if err := writeToDestination([]byte("x"), path, 0o644); err != nil {
 		t.Fatalf("writeToDestination: %v", err)

--- a/pkg/commands/kubeconfig_handler.go
+++ b/pkg/commands/kubeconfig_handler.go
@@ -101,62 +101,60 @@ Otherwise, kubeconfig will be written to PWD.`
 			return fmt.Errorf("failed to resolve kubeconfig path: %w", err)
 		}
 
-		if err == nil {
-			// Set secure permissions (600) on kubeconfig file. On Windows
-			// this lays down an NTFS DACL; os.Chmod would have been a no-op.
-			if err := secureperm.LockDown(absPath); err != nil {
-				// Don't fail the command if the tighten fails, but log warning
-				fmt.Fprintf(os.Stderr, "Warning: failed to set permissions on kubeconfig: %v\n", err)
-			}
+		// Set secure permissions (600) on kubeconfig file. On Windows
+		// this lays down an NTFS DACL; os.Chmod would have been a no-op.
+		if err := secureperm.LockDown(absPath); err != nil {
+			// Don't fail the command if the tighten fails, but log warning
+			fmt.Fprintf(os.Stderr, "Warning: failed to set permissions on kubeconfig: %v\n", err)
+		}
 
-			rootAbs, err := filepath.Abs(Config.RootDir)
-			if err == nil {
-				relPath, err := filepath.Rel(rootAbs, absPath)
-				if err == nil && !strings.HasPrefix(relPath, "..") {
-					// Path is within project root, add to .gitignore
-					fileName := filepath.Base(kubeconfigPath)
-					if fileName == "kubeconfig" {
-						if err := addToGitignore("kubeconfig"); err != nil {
-							// Don't fail the command if gitignore update fails
-							fmt.Fprintf(os.Stderr, "Warning: failed to update .gitignore: %v\n", err)
-						}
+		rootAbs, err := filepath.Abs(Config.RootDir)
+		if err == nil {
+			relPath, err := filepath.Rel(rootAbs, absPath)
+			if err == nil && !strings.HasPrefix(relPath, "..") {
+				// Path is within project root, add to .gitignore
+				fileName := filepath.Base(kubeconfigPath)
+				if fileName == "kubeconfig" {
+					if err := addToGitignore("kubeconfig"); err != nil {
+						// Don't fail the command if gitignore update fails
+						fmt.Fprintf(os.Stderr, "Warning: failed to update .gitignore: %v\n", err)
 					}
 				}
 			}
+		}
 
-			// Update kubeconfig server endpoint if endpoint is available
-			if len(GlobalArgs.Endpoints) > 0 {
-				endpoint := GlobalArgs.Endpoints[0]
-				if err := updateKubeconfigServer(absPath, endpoint); err != nil {
-					// Don't fail the command if update fails, but log warning
-					fmt.Fprintf(os.Stderr, "Warning: failed to update kubeconfig server endpoint: %v\n", err)
-				}
+		// Update kubeconfig server endpoint if endpoint is available
+		if len(GlobalArgs.Endpoints) > 0 {
+			endpoint := GlobalArgs.Endpoints[0]
+			if err := updateKubeconfigServer(absPath, endpoint); err != nil {
+				// Don't fail the command if update fails, but log warning
+				fmt.Fprintf(os.Stderr, "Warning: failed to update kubeconfig server endpoint: %v\n", err)
 			}
+		}
 
-			// Automatically update kubeconfig.encrypted if it exists and talm.key exists
-			// Skip this if --login flag is set
-			if !loginFlagValue {
-				// Get relative path from project root for encryption
-				rootAbs, err := filepath.Abs(Config.RootDir)
-				if err == nil {
-					relKubeconfigPath, err := filepath.Rel(rootAbs, absPath)
-					if err == nil && !strings.HasPrefix(relKubeconfigPath, "..") {
-						// Path is within project root
-						encryptedKubeconfigPath := relKubeconfigPath + ".encrypted"
-						encryptedKubeconfigFile := filepath.Join(Config.RootDir, encryptedKubeconfigPath)
-						keyFile := filepath.Join(Config.RootDir, "talm.key")
+		// Automatically update kubeconfig.encrypted if it exists and talm.key exists
+		// Skip this if --login flag is set
+		if !loginFlagValue {
+			// Get relative path from project root for encryption
+			rootAbs, err := filepath.Abs(Config.RootDir)
+			if err == nil {
+				relKubeconfigPath, err := filepath.Rel(rootAbs, absPath)
+				if err == nil && !strings.HasPrefix(relKubeconfigPath, "..") {
+					// Path is within project root
+					encryptedKubeconfigPath := relKubeconfigPath + ".encrypted"
+					encryptedKubeconfigFile := filepath.Join(Config.RootDir, encryptedKubeconfigPath)
+					keyFile := filepath.Join(Config.RootDir, "talm.key")
 
-						encryptedExists := fileExists(encryptedKubeconfigFile)
-						keyExists := fileExists(keyFile)
+					encryptedExists := fileExists(encryptedKubeconfigFile)
+					keyExists := fileExists(keyFile)
 
-						if encryptedExists && keyExists {
-							// Both files exist, encrypt kubeconfig
-							if err := age.EncryptYAMLFile(Config.RootDir, relKubeconfigPath, encryptedKubeconfigPath); err != nil {
-								// Don't fail the command if encryption fails, but log warning
-								fmt.Fprintf(os.Stderr, "Warning: failed to encrypt kubeconfig: %v\n", err)
-							} else {
-								fmt.Fprintf(os.Stderr, "Updated %s\n", encryptedKubeconfigPath)
-							}
+					if encryptedExists && keyExists {
+						// Both files exist, encrypt kubeconfig
+						if err := age.EncryptYAMLFile(Config.RootDir, relKubeconfigPath, encryptedKubeconfigPath); err != nil {
+							// Don't fail the command if encryption fails, but log warning
+							fmt.Fprintf(os.Stderr, "Warning: failed to encrypt kubeconfig: %v\n", err)
+						} else {
+							fmt.Fprintf(os.Stderr, "Updated %s\n", encryptedKubeconfigPath)
 						}
 					}
 				}

--- a/pkg/commands/kubeconfig_handler.go
+++ b/pkg/commands/kubeconfig_handler.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cozystack/talm/pkg/age"
 	"github.com/cozystack/talm/pkg/secureperm"
@@ -111,7 +110,7 @@ Otherwise, kubeconfig will be written to PWD.`
 		rootAbs, err := filepath.Abs(Config.RootDir)
 		if err == nil {
 			relPath, err := filepath.Rel(rootAbs, absPath)
-			if err == nil && !strings.HasPrefix(relPath, "..") {
+			if err == nil && !isOutsideRoot(relPath) {
 				// Path is within project root, add to .gitignore
 				fileName := filepath.Base(kubeconfigPath)
 				if fileName == "kubeconfig" {
@@ -139,7 +138,7 @@ Otherwise, kubeconfig will be written to PWD.`
 			rootAbs, err := filepath.Abs(Config.RootDir)
 			if err == nil {
 				relKubeconfigPath, err := filepath.Rel(rootAbs, absPath)
-				if err == nil && !strings.HasPrefix(relKubeconfigPath, "..") {
+				if err == nil && !isOutsideRoot(relKubeconfigPath) {
 					// Path is within project root
 					encryptedKubeconfigPath := relKubeconfigPath + ".encrypted"
 					encryptedKubeconfigFile := filepath.Join(Config.RootDir, encryptedKubeconfigPath)

--- a/pkg/commands/kubeconfig_handler.go
+++ b/pkg/commands/kubeconfig_handler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/cozystack/talm/pkg/age"
+	"github.com/cozystack/talm/pkg/secureperm"
 	"github.com/spf13/cobra"
 )
 
@@ -101,9 +102,10 @@ Otherwise, kubeconfig will be written to PWD.`
 		}
 
 		if err == nil {
-			// Set secure permissions (600) on kubeconfig file
-			if err := os.Chmod(absPath, 0o600); err != nil {
-				// Don't fail the command if chmod fails, but log warning
+			// Set secure permissions (600) on kubeconfig file. On Windows
+			// this lays down an NTFS DACL; os.Chmod would have been a no-op.
+			if err := secureperm.LockDown(absPath); err != nil {
+				// Don't fail the command if the tighten fails, but log warning
 				fmt.Fprintf(os.Stderr, "Warning: failed to set permissions on kubeconfig: %v\n", err)
 			}
 

--- a/pkg/commands/rotate_ca_handler.go
+++ b/pkg/commands/rotate_ca_handler.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cozystack/talm/pkg/age"
+	"github.com/cozystack/talm/pkg/secureperm"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/spf13/cobra"
@@ -363,7 +364,7 @@ func updateSecretsFromCluster(updateTalos, updateKubernetes bool, targetNode str
 		return fmt.Errorf("failed to marshal secrets: %w", err)
 	}
 
-	if err := os.WriteFile(secretsPath, data, 0o600); err != nil {
+	if err := secureperm.WriteFile(secretsPath, data); err != nil {
 		return fmt.Errorf("failed to write secrets.yaml: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "  Updated secrets.yaml\n")

--- a/pkg/commands/talosconfig.go
+++ b/pkg/commands/talosconfig.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cozystack/talm/pkg/secureperm"
+
 	"github.com/siderolabs/talos/cmd/talosctl/cmd/mgmt/gen"
 	"github.com/siderolabs/talos/pkg/machinery/client/config"
 	machineconfig "github.com/siderolabs/talos/pkg/machinery/config"
@@ -181,7 +183,7 @@ func regenerateTalosconfig() error {
 		return fmt.Errorf("failed to marshal talosconfig: %w", err)
 	}
 
-	if err := os.WriteFile(talosconfigFile, data, 0o600); err != nil {
+	if err := secureperm.WriteFile(talosconfigFile, data); err != nil {
 		return fmt.Errorf("failed to write talosconfig: %w", err)
 	}
 

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cozystack/talm/pkg/engine"
 	"github.com/cozystack/talm/pkg/modeline"
@@ -280,7 +279,7 @@ func generateOutput(ctx context.Context, c *client.Client, args []string) (strin
 			// Normalize the path (remove .. and .)
 			relPath = filepath.Clean(relPath)
 			// Check if path goes outside root
-			if strings.HasPrefix(relPath, "..") {
+			if isOutsideRoot(relPath) {
 				// Path goes outside root, try to find file in templates/ relative to root
 				// This handles cases like "../templates/controlplane.yaml" when file is actually in root/templates/
 				templateName := filepath.Base(templatePath)
@@ -421,7 +420,7 @@ func resolveEngineTemplatePaths(templateFiles []string, rootDir string) []string
 			continue
 		}
 		relPath = filepath.Clean(relPath)
-		if strings.HasPrefix(relPath, "..") {
+		if isOutsideRoot(relPath) {
 			templateName := filepath.Base(templatePath)
 			possiblePath := filepath.Join("templates", templateName)
 			fullPath := filepath.Join(absRootDir, possiblePath)

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -222,56 +222,7 @@ func generateOutput(ctx context.Context, c *client.Client, args []string) (strin
 	withSecretsPath := ResolveSecretsPath(templateCmdFlags.withSecrets)
 
 	// Resolve template file paths relative to project root
-	resolvedTemplateFiles := make([]string, len(templateCmdFlags.templateFiles))
-	absRootDir, rootErr := filepath.Abs(Config.RootDir)
-	if rootErr != nil {
-		// If we can't get absolute root, normalize original paths for helm engine
-		for i, p := range templateCmdFlags.templateFiles {
-			resolvedTemplateFiles[i] = engine.NormalizeTemplatePath(p)
-		}
-	} else {
-		for i, templatePath := range templateCmdFlags.templateFiles {
-			var absTemplatePath string
-			if filepath.IsAbs(templatePath) {
-				// Already absolute, use as is
-				absTemplatePath = templatePath
-			} else {
-				// Resolve relative path from current working directory
-				var absErr error
-				absTemplatePath, absErr = filepath.Abs(templatePath)
-				if absErr != nil {
-					// If we can't get absolute path, normalize original for helm engine
-					resolvedTemplateFiles[i] = engine.NormalizeTemplatePath(templatePath)
-					continue
-				}
-			}
-			// Convert to relative path from root
-			relPath, relErr := filepath.Rel(absRootDir, absTemplatePath)
-			if relErr != nil {
-				// If we can't get relative path, use original (normalized for helm engine)
-				resolvedTemplateFiles[i] = engine.NormalizeTemplatePath(templatePath)
-				continue
-			}
-			// Normalize the path (remove .. and .)
-			relPath = filepath.Clean(relPath)
-			// Check if path goes outside root
-			if strings.HasPrefix(relPath, "..") {
-				// Path goes outside root, try to find file in templates/ relative to root
-				templateName := filepath.Base(templatePath)
-				possiblePath := filepath.Join("templates", templateName)
-				fullPath := filepath.Join(absRootDir, possiblePath)
-				if _, statErr := os.Stat(fullPath); statErr == nil {
-					relPath = possiblePath
-				} else {
-					// Can't resolve, use original (normalized for helm engine)
-					resolvedTemplateFiles[i] = engine.NormalizeTemplatePath(templatePath)
-					continue
-				}
-			}
-			// Normalize path separators for helm engine (always uses forward slash)
-			resolvedTemplateFiles[i] = engine.NormalizeTemplatePath(relPath)
-		}
-	}
+	resolvedTemplateFiles := resolveEngineTemplatePaths(templateCmdFlags.templateFiles, Config.RootDir)
 
 	opts := engine.Options{
 		ValueFiles:        templateCmdFlags.valueFiles,
@@ -427,4 +378,61 @@ func writeInplaceRendered(configFile string, output string) error {
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "Updated.\n")
 	return nil
+}
+
+// resolveEngineTemplatePaths resolves each template path to a
+// forward-slash relative path under rootDir, ready to index into the
+// helm engine's map keys. Relative inputs are resolved against CWD
+// (matching the current shell context); if the resolved path lies
+// outside rootDir, the function falls back to `templates/<basename>`
+// under rootDir when such a file exists. Anything that cannot be
+// resolved is returned normalized through engine.NormalizeTemplatePath
+// so downstream map lookups never see backslashes.
+//
+// Extracted as a named function so Windows path handling can be
+// exercised directly in unit tests — PowerShell callers pass
+// backslash separators on `-t`, and a regression that reintroduces
+// backslashes into the engine-bound string would otherwise only be
+// observable at integration time.
+func resolveEngineTemplatePaths(templateFiles []string, rootDir string) []string {
+	resolved := make([]string, len(templateFiles))
+	absRootDir, rootErr := filepath.Abs(rootDir)
+	if rootErr != nil {
+		for i, p := range templateFiles {
+			resolved[i] = engine.NormalizeTemplatePath(p)
+		}
+		return resolved
+	}
+	for i, templatePath := range templateFiles {
+		var absTemplatePath string
+		if filepath.IsAbs(templatePath) {
+			absTemplatePath = templatePath
+		} else {
+			var absErr error
+			absTemplatePath, absErr = filepath.Abs(templatePath)
+			if absErr != nil {
+				resolved[i] = engine.NormalizeTemplatePath(templatePath)
+				continue
+			}
+		}
+		relPath, relErr := filepath.Rel(absRootDir, absTemplatePath)
+		if relErr != nil {
+			resolved[i] = engine.NormalizeTemplatePath(templatePath)
+			continue
+		}
+		relPath = filepath.Clean(relPath)
+		if strings.HasPrefix(relPath, "..") {
+			templateName := filepath.Base(templatePath)
+			possiblePath := filepath.Join("templates", templateName)
+			fullPath := filepath.Join(absRootDir, possiblePath)
+			if _, statErr := os.Stat(fullPath); statErr == nil {
+				relPath = possiblePath
+			} else {
+				resolved[i] = engine.NormalizeTemplatePath(templatePath)
+				continue
+			}
+		}
+		resolved[i] = engine.NormalizeTemplatePath(relPath)
+	}
+	return resolved
 }

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cozystack/talm/pkg/engine"
 	"github.com/cozystack/talm/pkg/modeline"
+	"github.com/cozystack/talm/pkg/secureperm"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -173,10 +174,9 @@ func templateWithFiles(args []string) func(ctx context.Context, c *client.Client
 					}
 
 					if templateCmdFlags.inplace {
-						if err = os.WriteFile(configFile, []byte(output), 0o644); err != nil {
-							return fmt.Errorf("failed to write file %s: %w", configFile, err)
+						if err := writeInplaceRendered(configFile, output); err != nil {
+							return err
 						}
-						fmt.Fprintf(os.Stderr, "Updated.\n")
 					} else {
 						if firstFileProcessed {
 							fmt.Println("---")
@@ -414,4 +414,17 @@ func init() {
 	templateCmd.Flags().StringVar(&templateCmdFlags.kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 
 	addCommand(templateCmd)
+}
+
+// writeInplaceRendered writes the rendered template output over the
+// node config file. Routes through secureperm because the rendered
+// machine config embeds certs, PKI keys, and cluster join tokens —
+// exactly the material that must not end up readable by other users
+// on Windows (inherited DACL) or Unix (0o644).
+func writeInplaceRendered(configFile string, output string) error {
+	if err := secureperm.WriteFile(configFile, []byte(output)); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", configFile, err)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Updated.\n")
+	return nil
 }

--- a/pkg/commands/template_test.go
+++ b/pkg/commands/template_test.go
@@ -25,6 +25,8 @@ import (
 // "..templates") is not mistaken for an outside-root path and routed
 // through the templates/<basename> fallback — that would silently
 // substitute a different file when one exists under templates/.
+//
+// Not safe with t.Parallel — uses os.Chdir, which is process-global.
 func TestResolveEngineTemplatePaths_DotDotPrefixedDir(t *testing.T) {
 	// Resolve symlinks so the rootDir and the post-Chdir cwd share the
 	// same canonical form — on macOS, t.TempDir lives under /var/...

--- a/pkg/commands/template_test.go
+++ b/pkg/commands/template_test.go
@@ -1,0 +1,69 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveEngineTemplatePaths_DotDotPrefixedDir pins that a
+// sibling directory whose name literally starts with ".." (e.g.
+// "..templates") is not mistaken for an outside-root path and routed
+// through the templates/<basename> fallback — that would silently
+// substitute a different file when one exists under templates/.
+func TestResolveEngineTemplatePaths_DotDotPrefixedDir(t *testing.T) {
+	// Resolve symlinks so the rootDir and the post-Chdir cwd share the
+	// same canonical form — on macOS, t.TempDir lives under /var/...
+	// but os.Getwd returns the realpath /private/var/... which throws
+	// off the Rel computation.
+	rootDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	// Seed both ..templates/controlplane.yaml (the real target) and
+	// templates/controlplane.yaml (a decoy the buggy fallback would
+	// have picked instead).
+	if err := os.MkdirAll(filepath.Join(rootDir, "..templates"), 0o755); err != nil {
+		t.Fatalf("mkdir ..templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "..templates", "controlplane.yaml"), []byte("real"), 0o600); err != nil {
+		t.Fatalf("seed ..templates/controlplane.yaml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "templates"), 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "templates", "controlplane.yaml"), []byte("decoy"), 0o600); err != nil {
+		t.Fatalf("seed templates/controlplane.yaml: %v", err)
+	}
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+	got := resolveEngineTemplatePaths([]string{"..templates/controlplane.yaml"}, rootDir)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != "..templates/controlplane.yaml" {
+		t.Errorf("got %q, want %q (the ..templates dir was misclassified as outside-root and routed through the basename fallback)", got[0], "..templates/controlplane.yaml")
+	}
+}

--- a/pkg/commands/template_unix_test.go
+++ b/pkg/commands/template_unix_test.go
@@ -56,6 +56,12 @@ func TestWriteInplaceRendered_OverwriteDowngrades_Unix(t *testing.T) {
 	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	// os.WriteFile is subject to the process umask, so force 0o644
+	// explicitly — otherwise a restrictive umask (e.g. 0o077) leaves
+	// the seed at 0o600 and the test passes vacuously.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
 	if err := writeInplaceRendered(path, "new"); err != nil {
 		t.Fatalf("writeInplaceRendered: %v", err)
 	}

--- a/pkg/commands/template_unix_test.go
+++ b/pkg/commands/template_unix_test.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteInplaceRendered_Mode0600_Unix pins that `talm template -i`
+// writes the rendered machine config through secureperm and not
+// os.WriteFile with 0o644. The rendered content embeds certs, PKI
+// keys, and cluster join tokens — leaving it world-readable would
+// defeat the whole secureperm migration.
+func TestWriteInplaceRendered_Mode0600_Unix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "node0.yaml")
+
+	if err := writeInplaceRendered(path, "apiVersion: v1alpha1\nkind: MachineConfig\n"); err != nil {
+		t.Fatalf("writeInplaceRendered: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 0600 (rendered machine config is secret)", got)
+	}
+}
+
+// TestWriteInplaceRendered_OverwriteDowngrades_Unix pins that running
+// `talm template -i` over a pre-existing node config with lax
+// permissions tightens the mode. An older talm may have written the
+// file at 0o644; on update the user expects the secret bits to be
+// tightened, not preserved.
+func TestWriteInplaceRendered_OverwriteDowngrades_Unix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "node0.yaml")
+
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := writeInplaceRendered(path, "new"); err != nil {
+		t.Fatalf("writeInplaceRendered: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode after overwrite = %o, want 0600", got)
+	}
+}

--- a/pkg/commands/template_windows_test.go
+++ b/pkg/commands/template_windows_test.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -119,7 +120,6 @@ func TestWriteInplaceRendered_ProtectedDACL_Windows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTokenUser: %v", err)
 	}
-	wantSid := tu.User.Sid.String()
 
 	if !strings.Contains(sddl, "D:P") {
 		t.Errorf("DACL not protected; SDDL=%q", sddl)
@@ -127,7 +127,27 @@ func TestWriteInplaceRendered_ProtectedDACL_Windows(t *testing.T) {
 	if got := strings.Count(sddl, "(A;"); got != 1 {
 		t.Errorf("DACL has %d Allow ACEs, want 1; SDDL=%q", got, sddl)
 	}
-	if !strings.Contains(sddl, wantSid) {
-		t.Errorf("DACL does not reference current user SID %q; SDDL=%q", wantSid, sddl)
+
+	// SDDL emits well-known SIDs as aliases (e.g. the RID-500 admin on
+	// GitHub Actions runners comes back as "LA" rather than the full
+	// "S-1-5-21-...-500"). Resolve the trustee string back through
+	// StringToSid and compare with EqualSid to get a robust match.
+	re := regexp.MustCompile(`\(A;([^)]+)\)`)
+	m := re.FindStringSubmatch(sddl)
+	if len(m) < 2 {
+		t.Fatalf("no Allow ACE found in SDDL %q", sddl)
+	}
+	fields := strings.Split(m[1], ";")
+	if len(fields) < 5 {
+		t.Fatalf("unexpected ACE shape %q", m[1])
+	}
+	trusteeStr := fields[4]
+	aceSid, err := windows.StringToSid(trusteeStr)
+	if err != nil {
+		t.Fatalf("StringToSid(%q): %v", trusteeStr, err)
+	}
+	if !windows.EqualSid(aceSid, tu.User.Sid) {
+		t.Errorf("ACE trustee %q (SID %s) != current user SID %s",
+			trusteeStr, aceSid.String(), tu.User.Sid.String())
 	}
 }

--- a/pkg/commands/template_windows_test.go
+++ b/pkg/commands/template_windows_test.go
@@ -39,6 +39,8 @@ import (
 // resolves relative against rootDir; template resolves relative
 // against CWD with a templates/<basename> fallback), so covering one
 // does not cover the other.
+//
+// Not safe with t.Parallel — uses os.Chdir, which is process-global.
 func TestResolveEngineTemplatePaths_BackslashInput(t *testing.T) {
 	rootDir := t.TempDir()
 	absRoot, err := filepath.Abs(rootDir)

--- a/pkg/commands/template_windows_test.go
+++ b/pkg/commands/template_windows_test.go
@@ -1,0 +1,133 @@
+//go:build windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestResolveEngineTemplatePaths_BackslashInput is the direct
+// regression guard for the original reproducer: a PowerShell user
+// invoking `talm template -t templates\controlplane.yaml` must end up
+// with a forward-slash path, because the helm engine only indexes
+// templates by forward-slash map keys. A backslash anywhere in the
+// output string means the engine emits "template not found".
+//
+// Exercising the template command's own resolver (not apply's near-
+// duplicate resolver in resolveTemplatePaths) is the point of this
+// test — the two code paths are structurally different (apply
+// resolves relative against rootDir; template resolves relative
+// against CWD with a templates/<basename> fallback), so covering one
+// does not cover the other.
+func TestResolveEngineTemplatePaths_BackslashInput(t *testing.T) {
+	rootDir := t.TempDir()
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+
+	// Seed templates/controlplane.yaml so the fallback branch has
+	// something to find.
+	if err := os.MkdirAll(filepath.Join(absRoot, "templates"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(absRoot, "templates", "controlplane.yaml"), []byte{}, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Chdir so relative paths resolve against rootDir exactly as they
+	// would when a user cd's into their project directory and runs
+	// `talm template -t templates\controlplane.yaml`.
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+	inputs := []string{
+		`templates\controlplane.yaml`,
+		`templates\nested\worker.yaml`,
+		`templates\nested/mixed.yaml`,
+		filepath.Join(absRoot, "templates", "controlplane.yaml"),
+	}
+
+	got := resolveEngineTemplatePaths(inputs, rootDir)
+	if len(got) != len(inputs) {
+		t.Fatalf("len mismatch: got %d, want %d", len(got), len(inputs))
+	}
+	for i, r := range got {
+		if strings.ContainsRune(r, '\\') {
+			t.Errorf("input[%d]=%q resolved to %q which contains backslash; helm engine lookup would fail",
+				i, inputs[i], r)
+		}
+	}
+}
+
+// TestWriteInplaceRendered_ProtectedDACL_Windows pins that `talm
+// template --inplace` writes the rendered Talos machine config (which
+// embeds certs, PKI keys, and cluster join tokens) under an NTFS
+// protected owner-only DACL, not under the directory's inherited
+// permissive one. The SDDL assertion mirrors the shape used in
+// pkg/secureperm/secureperm_windows_test.go — a protected DACL with
+// exactly one Allow ACE naming the current user SID.
+func TestWriteInplaceRendered_ProtectedDACL_Windows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "node0.yaml")
+
+	if err := writeInplaceRendered(path, "apiVersion: v1alpha1\nkind: MachineConfig\n"); err != nil {
+		t.Fatalf("writeInplaceRendered: %v", err)
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo: %v", err)
+	}
+	sddl := sd.String()
+
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		t.Fatalf("OpenProcessToken: %v", err)
+	}
+	defer func() { _ = token.Close() }()
+	tu, err := token.GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser: %v", err)
+	}
+	wantSid := tu.User.Sid.String()
+
+	if !strings.Contains(sddl, "D:P") {
+		t.Errorf("DACL not protected; SDDL=%q", sddl)
+	}
+	if got := strings.Count(sddl, "(A;"); got != 1 {
+		t.Errorf("DACL has %d Allow ACEs, want 1; SDDL=%q", got, sddl)
+	}
+	if !strings.Contains(sddl, wantSid) {
+		t.Errorf("DACL does not reference current user SID %q; SDDL=%q", wantSid, sddl)
+	}
+}

--- a/pkg/secureperm/secureperm.go
+++ b/pkg/secureperm/secureperm.go
@@ -16,9 +16,14 @@
 // (age private keys, decrypted secrets.yaml, talosconfig, kubeconfig)
 // so that only the file owner can read them.
 //
-// On Unix the implementation is a thin wrapper over os.WriteFile and
-// os.Chmod with mode 0o600. On Windows os.Chmod does not translate to
-// NTFS DACLs — files inherit ACLs from their parent and remain readable
-// by BUILTIN\Users. The Windows implementation (secureperm_windows.go)
-// additionally sets a protected DACL granting only the current user SID.
+// On Unix WriteFile is os.WriteFile(…, 0o600) followed by an explicit
+// os.Chmod — the trailing Chmod is required because os.WriteFile keeps
+// a pre-existing file's mode bits untouched on overwrite.
+//
+// On Windows os.Chmod does not translate to NTFS DACLs — files inherit
+// ACLs from their parent and remain readable by BUILTIN\Users. The
+// Windows implementation creates the file with a protected DACL
+// granting only the current user SID, installed via CreateFile's
+// SECURITY_ATTRIBUTES argument. The file's contents never exist on
+// disk under a lax DACL, even for a moment.
 package secureperm

--- a/pkg/secureperm/secureperm.go
+++ b/pkg/secureperm/secureperm.go
@@ -21,9 +21,14 @@
 // a pre-existing file's mode bits untouched on overwrite.
 //
 // On Windows os.Chmod does not translate to NTFS DACLs — files inherit
-// ACLs from their parent and remain readable by BUILTIN\Users. The
-// Windows implementation creates the file with a protected DACL
-// granting only the current user SID, installed via CreateFile's
-// SECURITY_ATTRIBUTES argument. The file's contents never exist on
-// disk under a lax DACL, even for a moment.
+// ACLs from their parent, which may leave secrets readable by
+// non-owner principals such as BUILTIN\Users. The Windows
+// implementation creates the file with a protected owner-only DACL
+// via CreateFile's SECURITY_ATTRIBUTES argument, then immediately
+// calls SetSecurityInfo on the handle (before any bytes are written)
+// to cover the overwrite case: per MSDN, CreateFile ignores
+// SECURITY_ATTRIBUTES when opening an existing file, so the handle
+// would otherwise keep the prior DACL. Because the handle is opened
+// exclusive, no other process can observe the file between the DACL
+// switch and the write.
 package secureperm

--- a/pkg/secureperm/secureperm.go
+++ b/pkg/secureperm/secureperm.go
@@ -13,22 +13,36 @@
 // limitations under the License.
 
 // Package secureperm writes and locks down files that hold secrets
-// (age private keys, decrypted secrets.yaml, talosconfig, kubeconfig)
-// so that only the file owner can read them.
+// (age private keys, decrypted secrets.yaml, talosconfig, kubeconfig,
+// rendered Talos machine configs) so that only the file owner can
+// read them.
 //
-// On Unix WriteFile is os.WriteFile(…, 0o600) followed by an explicit
-// os.Chmod — the trailing Chmod is required because os.WriteFile keeps
-// a pre-existing file's mode bits untouched on overwrite.
+// WriteFile is atomic on both platforms via write-to-tmp + rename:
+// it creates a hidden sibling tmp file in the same directory with the
+// final permissions already in place, writes the bytes, then renames
+// the tmp over the target. os.Rename is atomic on POSIX and on NTFS
+// when source and destination share a filesystem (which they do by
+// construction here). On any pre-rename failure the tmp is removed
+// and the destination is left in its prior state — important because
+// secrets are not reconstructible (a corrupted secrets.yaml forces a
+// cluster PKI reissue).
 //
-// On Windows os.Chmod does not translate to NTFS DACLs — files inherit
-// ACLs from their parent, which may leave secrets readable by
-// non-owner principals such as BUILTIN\Users. The Windows
-// implementation creates the file with a protected owner-only DACL
-// via CreateFile's SECURITY_ATTRIBUTES argument, then immediately
-// calls SetSecurityInfo on the handle (before any bytes are written)
-// to cover the overwrite case: per MSDN, CreateFile ignores
-// SECURITY_ATTRIBUTES when opening an existing file, so the handle
-// would otherwise keep the prior DACL. Because the handle is opened
-// exclusive, no other process can observe the file between the DACL
-// switch and the write.
+// On Unix the tmp is created via os.CreateTemp (O_CREATE|O_EXCL|O_RDWR
+// with mode 0o600 by construction) plus an explicit Chmod so the
+// contract survives any future stdlib change.
+//
+// On Windows os.Chmod does not translate to NTFS DACLs — files
+// ordinarily inherit ACLs from their parent, which may leave secrets
+// readable by non-owner principals such as BUILTIN\Users. The tmp is
+// created via CreateFile with CREATE_NEW and a SECURITY_ATTRIBUTES
+// descriptor carrying a protected owner-only DACL. CREATE_NEW is the
+// key: per MSDN, CreateFile only honors the lpSecurityDescriptor
+// argument when the file is newly created, not when it opens an
+// existing file — so the retry loop picks a name that does not
+// exist, guaranteeing the DACL actually lands. The rename step then
+// overwrites the destination with the tmp, carrying the tmp's
+// owner-only DACL over in place of whatever permissive inherited
+// DACL the destination held. The bytes never exist on disk under a
+// lax DACL, and because the tmp handle is opened with share mode 0
+// no other process can open it between creation and rename.
 package secureperm

--- a/pkg/secureperm/secureperm.go
+++ b/pkg/secureperm/secureperm.go
@@ -1,0 +1,24 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secureperm writes and locks down files that hold secrets
+// (age private keys, decrypted secrets.yaml, talosconfig, kubeconfig)
+// so that only the file owner can read them.
+//
+// On Unix the implementation is a thin wrapper over os.WriteFile and
+// os.Chmod with mode 0o600. On Windows os.Chmod does not translate to
+// NTFS DACLs — files inherit ACLs from their parent and remain readable
+// by BUILTIN\Users. The Windows implementation (secureperm_windows.go)
+// additionally sets a protected DACL granting only the current user SID.
+package secureperm

--- a/pkg/secureperm/secureperm_test.go
+++ b/pkg/secureperm/secureperm_test.go
@@ -1,0 +1,61 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureperm_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cozystack/talm/pkg/secureperm"
+)
+
+func TestWriteFile_PersistsContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	payload := []byte("topsecret")
+
+	if err := secureperm.WriteFile(path, payload); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("content mismatch: got %q, want %q", got, payload)
+	}
+}
+
+func TestLockDown_OnExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := secureperm.LockDown(path); err != nil {
+		t.Fatalf("LockDown: %v", err)
+	}
+
+	// Re-read to confirm the file is still accessible to the owner after
+	// tightening. On Unix this is trivial; on Windows this verifies the
+	// DACL did not accidentally exclude the current user.
+	if _, err := os.ReadFile(path); err != nil {
+		t.Fatalf("owner cannot read locked file: %v", err)
+	}
+}

--- a/pkg/secureperm/secureperm_unix.go
+++ b/pkg/secureperm/secureperm_unix.go
@@ -16,18 +16,56 @@
 
 package secureperm
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
 
-// WriteFile writes data to path with mode 0o600. os.WriteFile only
-// applies the mode argument when creating the file — on overwrite it
-// preserves whatever bits were there, so a pre-existing 0o644 secrets
-// file would stay world-readable after rewrite. An explicit Chmod
-// afterwards guarantees the final mode regardless of prior state.
+// WriteFile writes data to path atomically with mode 0o600.
+//
+// Atomic in the sense that either the write fully succeeds and path
+// references the new content, or it fails and path is left in its
+// prior state — secrets files are not reconstructible (losing
+// secrets.yaml means reissuing cluster PKI), so the helper must not
+// destroy the existing file if the write can't complete.
+//
+// Strategy: create a hidden sibling tmp file in the same directory via
+// os.CreateTemp (which uses O_CREATE|O_EXCL|O_RDWR with mode 0o600,
+// so the tmp is already owner-only), write the bytes, then rename
+// over the target. Rename is atomic on POSIX when both paths live on
+// the same filesystem, which they do by construction.
 func WriteFile(path string, data []byte) error {
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return err
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".secureperm-*")
+	if err != nil {
+		return fmt.Errorf("create tmp in %s: %w", dir, err)
 	}
-	return os.Chmod(path, 0o600)
+	tmpPath := f.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// os.CreateTemp already uses 0o600 but enforce explicitly so the
+	// contract survives any future stdlib change.
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("chmod tmp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename tmp -> %s: %w", path, err)
+	}
+	committed = true
+	return nil
 }
 
 // LockDown narrows an existing file's permissions to 0o600.

--- a/pkg/secureperm/secureperm_unix.go
+++ b/pkg/secureperm/secureperm_unix.go
@@ -18,9 +18,16 @@ package secureperm
 
 import "os"
 
-// WriteFile writes data to path with mode 0o600.
+// WriteFile writes data to path with mode 0o600. os.WriteFile only
+// applies the mode argument when creating the file — on overwrite it
+// preserves whatever bits were there, so a pre-existing 0o644 secrets
+// file would stay world-readable after rewrite. An explicit Chmod
+// afterwards guarantees the final mode regardless of prior state.
 func WriteFile(path string, data []byte) error {
-	return os.WriteFile(path, data, 0o600)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 // LockDown narrows an existing file's permissions to 0o600.

--- a/pkg/secureperm/secureperm_unix.go
+++ b/pkg/secureperm/secureperm_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureperm
+
+import "os"
+
+// WriteFile writes data to path with mode 0o600.
+func WriteFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}
+
+// LockDown narrows an existing file's permissions to 0o600.
+func LockDown(path string) error {
+	return os.Chmod(path, 0o600)
+}

--- a/pkg/secureperm/secureperm_unix.go
+++ b/pkg/secureperm/secureperm_unix.go
@@ -58,6 +58,15 @@ func WriteFile(path string, data []byte) error {
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("write tmp: %w", err)
 	}
+	// fsync the tmp file before rename so its contents are on stable
+	// storage; otherwise a crash/power-loss between rename and the
+	// delayed disk flush can surface the renamed inode pointing at
+	// zero-length or stale data on reboot — the canonical failure mode
+	// the atomic-rename pattern is meant to avoid. Secrets files are
+	// not reconstructible, so the full fsync is warranted.
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync tmp: %w", err)
+	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("close tmp: %w", err)
 	}
@@ -65,6 +74,13 @@ func WriteFile(path string, data []byte) error {
 		return fmt.Errorf("rename tmp -> %s: %w", path, err)
 	}
 	committed = true
+	// Best-effort fsync of the parent dir so the rename entry itself is
+	// durable. Ignored errors: dir fsync is unsupported on a few
+	// filesystems; the tmp fsync above already protects the payload.
+	if d, openErr := os.Open(dir); openErr == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
 	return nil
 }
 

--- a/pkg/secureperm/secureperm_unix.go
+++ b/pkg/secureperm/secureperm_unix.go
@@ -35,6 +35,15 @@ import (
 // so the tmp is already owner-only), write the bytes, then rename
 // over the target. Rename is atomic on POSIX when both paths live on
 // the same filesystem, which they do by construction.
+//
+// Ownership note: tmp + rename produces a file owned by the calling
+// process's uid/gid, which differs from os.WriteFile's open-with-
+// O_TRUNC behaviour where the existing inode's owner is preserved.
+// Running talm under a different uid than a previous invocation
+// (e.g. once via sudo, then as the unprivileged user) will therefore
+// change ownership on the secrets file. The single-user workstation
+// flow this helper targets is unaffected; mixed-uid setups should
+// invoke talm under a consistent identity.
 func WriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, ".secureperm-*")

--- a/pkg/secureperm/secureperm_unix_test.go
+++ b/pkg/secureperm/secureperm_unix_test.go
@@ -60,3 +60,27 @@ func TestLockDown_Mode0600_Unix(t *testing.T) {
 		t.Errorf("mode = %o, want 0600", got)
 	}
 }
+
+// TestWriteFile_OverwriteDowngrades_Unix pins the behavior that
+// rewriting an existing file with lax permissions tightens them.
+// os.WriteFile alone preserves prior mode bits on overwrite, so this
+// test fails unless WriteFile follows up with an explicit Chmod.
+func TestWriteFile_OverwriteDowngrades_Unix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lax.txt")
+
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := secureperm.WriteFile(path, []byte("new")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode after overwrite = %o, want 0600", got)
+	}
+}

--- a/pkg/secureperm/secureperm_unix_test.go
+++ b/pkg/secureperm/secureperm_unix_test.go
@@ -48,6 +48,13 @@ func TestLockDown_Mode0600_Unix(t *testing.T) {
 	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	// os.WriteFile is subject to the process umask; force 0o644 so the
+	// lax-mode precondition is deterministic regardless of the host
+	// umask (a restrictive 0o077 would otherwise make the seed 0o600
+	// and the test pass without proving LockDown tightened anything).
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
 	if err := secureperm.LockDown(path); err != nil {
 		t.Fatalf("LockDown: %v", err)
 	}
@@ -71,6 +78,12 @@ func TestWriteFile_OverwriteDowngrades_Unix(t *testing.T) {
 
 	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
+	}
+	// Force the seed mode so the lax precondition survives a
+	// restrictive umask; otherwise the test can pass without actually
+	// verifying that WriteFile downgraded 0o644 to 0o600.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod seed: %v", err)
 	}
 	if err := secureperm.WriteFile(path, []byte("new")); err != nil {
 		t.Fatalf("WriteFile: %v", err)

--- a/pkg/secureperm/secureperm_unix_test.go
+++ b/pkg/secureperm/secureperm_unix_test.go
@@ -1,0 +1,62 @@
+//go:build !windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureperm_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cozystack/talm/pkg/secureperm"
+)
+
+func TestWriteFile_Mode0600_Unix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+
+	if err := secureperm.WriteFile(path, []byte("x")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 0600", got)
+	}
+}
+
+func TestLockDown_Mode0600_Unix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := secureperm.LockDown(path); err != nil {
+		t.Fatalf("LockDown: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 0600", got)
+	}
+}

--- a/pkg/secureperm/secureperm_unix_test.go
+++ b/pkg/secureperm/secureperm_unix_test.go
@@ -62,9 +62,9 @@ func TestLockDown_Mode0600_Unix(t *testing.T) {
 }
 
 // TestWriteFile_OverwriteDowngrades_Unix pins the behavior that
-// rewriting an existing file with lax permissions tightens them.
-// os.WriteFile alone preserves prior mode bits on overwrite, so this
-// test fails unless WriteFile follows up with an explicit Chmod.
+// rewriting an existing file with lax permissions tightens them. The
+// atomic tmp+rename strategy achieves this because the renamed tmp
+// file was created with 0o600.
 func TestWriteFile_OverwriteDowngrades_Unix(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "lax.txt")
@@ -82,5 +82,45 @@ func TestWriteFile_OverwriteDowngrades_Unix(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Errorf("mode after overwrite = %o, want 0600", got)
+	}
+}
+
+// TestWriteFile_PreservesOriginalOnFailure_Unix asserts the atomic
+// write contract: if the write cannot complete, the original file's
+// content is left intact. Secrets files are not reconstructible —
+// corrupting secrets.yaml costs the user a cluster rebuild.
+//
+// Failure is induced by marking the parent directory read-only, which
+// makes os.CreateTemp fail with EACCES inside the tmp-creation step.
+// The existing target file has content that must survive.
+func TestWriteFile_PreservesOriginalOnFailure_Unix(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — directory permission bits are ignored")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.yaml")
+
+	original := []byte("critical-content-DO-NOT-LOSE")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Make the directory non-writable so os.CreateTemp fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := secureperm.WriteFile(path, []byte("replacement"))
+	if err == nil {
+		t.Fatal("expected WriteFile to fail on read-only directory")
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("original file missing after failure: %v", readErr)
+	}
+	if string(got) != string(original) {
+		t.Errorf("original content corrupted on failure:\nwant %q\n got %q", original, got)
 	}
 }

--- a/pkg/secureperm/secureperm_windows.go
+++ b/pkg/secureperm/secureperm_windows.go
@@ -59,12 +59,17 @@ func ownerOnlyDACL() (*windows.ACL, error) {
 	return acl, nil
 }
 
-// WriteFile creates path with a protected DACL granting only the
-// current user SID, then writes data. Using CreateFile with a
-// SECURITY_ATTRIBUTES descriptor means the file's contents never touch
-// disk under the parent directory's inherited (likely permissive) ACL
-// — closing the write-then-tighten race that a naive os.WriteFile +
-// LockDown sequence would leave open.
+// WriteFile writes data to path under a protected DACL granting only
+// the current user SID.
+//
+// For new files the DACL is installed at creation via CreateFile's
+// SECURITY_ATTRIBUTES. For existing files CreateFile + CREATE_ALWAYS
+// silently ignores SECURITY_ATTRIBUTES (per MSDN), so we additionally
+// call SetSecurityInfo on the open handle before writing any bytes —
+// the handle was opened exclusive (no share-mode), so no other process
+// can observe the file between the old DACL and the new one. After
+// SetSecurityInfo returns, the write proceeds under the owner-only
+// DACL and the final on-disk state is always protected.
 func WriteFile(path string, data []byte) error {
 	dacl, err := ownerOnlyDACL()
 	if err != nil {
@@ -78,8 +83,6 @@ func WriteFile(path string, data []byte) error {
 	if err := sd.SetDACL(dacl, true, false); err != nil {
 		return fmt.Errorf("attach DACL: %w", err)
 	}
-	// Mark the DACL as protected so inherited ACEs from the parent
-	// directory are stripped rather than merged.
 	if err := sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
 		return fmt.Errorf("protect DACL: %w", err)
 	}
@@ -97,7 +100,7 @@ func WriteFile(path string, data []byte) error {
 
 	handle, err := windows.CreateFile(
 		pathUTF16,
-		windows.GENERIC_WRITE,
+		windows.GENERIC_WRITE|windows.WRITE_DAC,
 		0, // exclusive — no sharing during write
 		&sa,
 		windows.CREATE_ALWAYS,
@@ -110,6 +113,20 @@ func WriteFile(path string, data []byte) error {
 
 	f := os.NewFile(uintptr(handle), path)
 	defer func() { _ = f.Close() }()
+
+	// Force the DACL onto the handle before writing bytes. Covers the
+	// overwrite case where SECURITY_ATTRIBUTES from CreateFile is
+	// ignored. Uses SetSecurityInfo on the handle (not the path) so
+	// nothing can re-open the file between the DACL switch and the
+	// write — share mode on the handle is 0.
+	if err := windows.SetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	); err != nil {
+		return fmt.Errorf("set handle DACL on %s: %w", path, err)
+	}
 
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("write secure file %s: %w", path, err)

--- a/pkg/secureperm/secureperm_windows.go
+++ b/pkg/secureperm/secureperm_windows.go
@@ -145,9 +145,6 @@ func createSecureTmp(dir string) (tmpPath string, handle windows.Handle, err err
 // rename succeeds.
 func WriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
-	if dir == "" {
-		dir = "."
-	}
 
 	tmpPath, handle, err := createSecureTmp(dir)
 	if err != nil {
@@ -165,6 +162,17 @@ func WriteFile(path string, data []byte) error {
 
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("write tmp %s: %w", tmpPath, err)
+	}
+	// FlushFileBuffers (the Windows backend for *os.File.Sync) before
+	// rename so the tmp's contents are on stable storage. os.Rename on
+	// Windows uses MoveFileEx without MOVEFILE_WRITE_THROUGH, so a
+	// crash/power-loss between rename and the OS cache flush would
+	// otherwise surface the renamed file pointing at zero-length or
+	// stale data on reboot — the canonical failure mode the atomic-
+	// rename pattern is meant to avoid. Secrets files are not
+	// reconstructible, so the flush is warranted.
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync tmp %s: %w", tmpPath, err)
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("close tmp %s: %w", tmpPath, err)

--- a/pkg/secureperm/secureperm_windows.go
+++ b/pkg/secureperm/secureperm_windows.go
@@ -19,35 +19,25 @@ package secureperm
 import (
 	"fmt"
 	"os"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-// WriteFile writes data to path and then tightens the NTFS DACL so only
-// the current user SID has access. os.WriteFile's mode argument is
-// effectively ignored on Windows — without the DACL step the file
-// inherits the parent directory's ACL and remains readable by
-// BUILTIN\Users.
-func WriteFile(path string, data []byte) error {
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return err
-	}
-	return LockDown(path)
-}
-
-// LockDown replaces the DACL on an existing file with a single ACE
-// granting the current user full control, and marks the DACL as
-// protected so inherited ACEs are stripped.
-func LockDown(path string) error {
+// ownerOnlyDACL builds an ACL with a single Allow ACE granting full
+// control to the current process user SID, with no inheritance. Used
+// by both WriteFile (at create time) and LockDown (to rewrite an
+// existing file's DACL).
+func ownerOnlyDACL() (*windows.ACL, error) {
 	var token windows.Token
 	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
-		return fmt.Errorf("open process token: %w", err)
+		return nil, fmt.Errorf("open process token: %w", err)
 	}
 	defer func() { _ = token.Close() }()
 
 	tokenUser, err := token.GetTokenUser()
 	if err != nil {
-		return fmt.Errorf("get token user: %w", err)
+		return nil, fmt.Errorf("get token user: %w", err)
 	}
 
 	entries := []windows.EXPLICIT_ACCESS{
@@ -62,11 +52,79 @@ func LockDown(path string) error {
 			},
 		},
 	}
-	dacl, err := windows.ACLFromEntries(entries, nil)
+	acl, err := windows.ACLFromEntries(entries, nil)
 	if err != nil {
-		return fmt.Errorf("build DACL: %w", err)
+		return nil, fmt.Errorf("build DACL: %w", err)
+	}
+	return acl, nil
+}
+
+// WriteFile creates path with a protected DACL granting only the
+// current user SID, then writes data. Using CreateFile with a
+// SECURITY_ATTRIBUTES descriptor means the file's contents never touch
+// disk under the parent directory's inherited (likely permissive) ACL
+// — closing the write-then-tighten race that a naive os.WriteFile +
+// LockDown sequence would leave open.
+func WriteFile(path string, data []byte) error {
+	dacl, err := ownerOnlyDACL()
+	if err != nil {
+		return err
 	}
 
+	sd, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		return fmt.Errorf("create security descriptor: %w", err)
+	}
+	if err := sd.SetDACL(dacl, true, false); err != nil {
+		return fmt.Errorf("attach DACL: %w", err)
+	}
+	// Mark the DACL as protected so inherited ACEs from the parent
+	// directory are stripped rather than merged.
+	if err := sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
+		return fmt.Errorf("protect DACL: %w", err)
+	}
+
+	sa := windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: sd,
+		InheritHandle:      0,
+	}
+
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return fmt.Errorf("encode path: %w", err)
+	}
+
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		windows.GENERIC_WRITE,
+		0, // exclusive — no sharing during write
+		&sa,
+		windows.CREATE_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("create secure file %s: %w", path, err)
+	}
+
+	f := os.NewFile(uintptr(handle), path)
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write secure file %s: %w", path, err)
+	}
+	return nil
+}
+
+// LockDown replaces the DACL on an existing file with a single ACE
+// granting the current user full control, and marks the DACL as
+// protected so inherited ACEs are stripped.
+func LockDown(path string) error {
+	dacl, err := ownerOnlyDACL()
+	if err != nil {
+		return err
+	}
 	if err := windows.SetNamedSecurityInfo(
 		path,
 		windows.SE_FILE_OBJECT,

--- a/pkg/secureperm/secureperm_windows.go
+++ b/pkg/secureperm/secureperm_windows.go
@@ -1,0 +1,79 @@
+//go:build windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureperm
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// WriteFile writes data to path and then tightens the NTFS DACL so only
+// the current user SID has access. os.WriteFile's mode argument is
+// effectively ignored on Windows — without the DACL step the file
+// inherits the parent directory's ACL and remains readable by
+// BUILTIN\Users.
+func WriteFile(path string, data []byte) error {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	return LockDown(path)
+}
+
+// LockDown replaces the DACL on an existing file with a single ACE
+// granting the current user full control, and marks the DACL as
+// protected so inherited ACEs are stripped.
+func LockDown(path string) error {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return fmt.Errorf("open process token: %w", err)
+	}
+	defer func() { _ = token.Close() }()
+
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get token user: %w", err)
+	}
+
+	entries := []windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(tokenUser.User.Sid),
+			},
+		},
+	}
+	dacl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return fmt.Errorf("build DACL: %w", err)
+	}
+
+	if err := windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	); err != nil {
+		return fmt.Errorf("set file DACL: %w", err)
+	}
+	return nil
+}

--- a/pkg/secureperm/secureperm_windows.go
+++ b/pkg/secureperm/secureperm_windows.go
@@ -17,8 +17,11 @@
 package secureperm
 
 import (
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"os"
+	"path/filepath"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -26,8 +29,7 @@ import (
 
 // ownerOnlyDACL builds an ACL with a single Allow ACE granting full
 // control to the current process user SID, with no inheritance. Used
-// by both WriteFile (at create time) and LockDown (to rewrite an
-// existing file's DACL).
+// by both WriteFile (when creating the tmp sibling) and LockDown.
 func ownerOnlyDACL() (*windows.ACL, error) {
 	var token windows.Token
 	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
@@ -59,78 +61,118 @@ func ownerOnlyDACL() (*windows.ACL, error) {
 	return acl, nil
 }
 
-// WriteFile writes data to path under a protected DACL granting only
-// the current user SID.
-//
-// For new files the DACL is installed at creation via CreateFile's
-// SECURITY_ATTRIBUTES. For existing files CreateFile + CREATE_ALWAYS
-// silently ignores SECURITY_ATTRIBUTES (per MSDN), so we additionally
-// call SetSecurityInfo on the open handle before writing any bytes —
-// the handle was opened exclusive (no share-mode), so no other process
-// can observe the file between the old DACL and the new one. After
-// SetSecurityInfo returns, the write proceeds under the owner-only
-// DACL and the final on-disk state is always protected.
-func WriteFile(path string, data []byte) error {
+// ownerOnlyDescriptor bundles the owner-only DACL into a protected
+// SECURITY_DESCRIPTOR ready to hand to CreateFile.
+func ownerOnlyDescriptor() (*windows.SECURITY_DESCRIPTOR, error) {
 	dacl, err := ownerOnlyDACL()
 	if err != nil {
-		return err
+		return nil, err
 	}
-
 	sd, err := windows.NewSecurityDescriptor()
 	if err != nil {
-		return fmt.Errorf("create security descriptor: %w", err)
+		return nil, fmt.Errorf("create security descriptor: %w", err)
 	}
 	if err := sd.SetDACL(dacl, true, false); err != nil {
-		return fmt.Errorf("attach DACL: %w", err)
+		return nil, fmt.Errorf("attach DACL: %w", err)
 	}
+	// Mark the DACL protected so inherited ACEs are stripped rather
+	// than merged.
 	if err := sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
-		return fmt.Errorf("protect DACL: %w", err)
+		return nil, fmt.Errorf("protect DACL: %w", err)
 	}
+	return sd, nil
+}
 
+// createSecureTmp picks an unused path in dir and creates the file via
+// CreateFile with CREATE_NEW + a protected owner-only SECURITY_-
+// ATTRIBUTES. CREATE_NEW is important: CreateFile ignores the SA
+// member when opening an existing file, so using the NEW variant on a
+// filename we already verified didn't exist is what makes the DACL
+// actually apply at creation time.
+func createSecureTmp(dir string) (tmpPath string, handle windows.Handle, err error) {
+	sd, err := ownerOnlyDescriptor()
+	if err != nil {
+		return "", 0, err
+	}
 	sa := windows.SecurityAttributes{
 		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
 		SecurityDescriptor: sd,
 		InheritHandle:      0,
 	}
 
-	pathUTF16, err := windows.UTF16PtrFromString(path)
+	for range 100 {
+		candidate := filepath.Join(dir, fmt.Sprintf(".secureperm-%d-%d", os.Getpid(), rand.Uint32()))
+		utf16, err := windows.UTF16PtrFromString(candidate)
+		if err != nil {
+			return "", 0, fmt.Errorf("encode tmp path: %w", err)
+		}
+		h, err := windows.CreateFile(
+			utf16,
+			windows.GENERIC_WRITE,
+			0, // exclusive — no sharing during write
+			&sa,
+			windows.CREATE_NEW,
+			windows.FILE_ATTRIBUTE_NORMAL,
+			0,
+		)
+		if err == nil {
+			return candidate, h, nil
+		}
+		if !errors.Is(err, windows.ERROR_FILE_EXISTS) && !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			return "", 0, fmt.Errorf("create tmp %s: %w", candidate, err)
+		}
+		// Name already in use — pick another.
+	}
+	return "", 0, errors.New("could not find unused tmp filename after 100 attempts")
+}
+
+// WriteFile writes data to path atomically under a protected DACL
+// granting only the current user SID.
+//
+// Atomic in the sense that either the write fully succeeds and path
+// references the new content, or it fails and the prior file is left
+// intact. Secrets files are not reconstructible (losing secrets.yaml
+// means reissuing cluster PKI), so the helper must not destroy the
+// existing file if the write can't complete.
+//
+// Strategy: create a hidden sibling tmp with CreateFile + CREATE_NEW +
+// SECURITY_ATTRIBUTES (protected owner-only DACL), write the bytes,
+// close the handle, rename over the target. Rename uses Win32
+// MoveFileEx with MOVEFILE_REPLACE_EXISTING under the hood (os.Rename
+// on Windows), which preserves the tmp's owner-only DACL on the final
+// file. At no point do the new bytes exist on disk under a permissive
+// DACL, and the old bytes remain readable by the owner until the final
+// rename succeeds.
+func WriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+
+	tmpPath, handle, err := createSecureTmp(dir)
 	if err != nil {
-		return fmt.Errorf("encode path: %w", err)
+		return err
 	}
 
-	handle, err := windows.CreateFile(
-		pathUTF16,
-		windows.GENERIC_WRITE|windows.WRITE_DAC,
-		0, // exclusive — no sharing during write
-		&sa,
-		windows.CREATE_ALWAYS,
-		windows.FILE_ATTRIBUTE_NORMAL,
-		0,
-	)
-	if err != nil {
-		return fmt.Errorf("create secure file %s: %w", path, err)
-	}
-
-	f := os.NewFile(uintptr(handle), path)
-	defer func() { _ = f.Close() }()
-
-	// Force the DACL onto the handle before writing bytes. Covers the
-	// overwrite case where SECURITY_ATTRIBUTES from CreateFile is
-	// ignored. Uses SetSecurityInfo on the handle (not the path) so
-	// nothing can re-open the file between the DACL switch and the
-	// write — share mode on the handle is 0.
-	if err := windows.SetSecurityInfo(
-		handle,
-		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		nil, nil, dacl, nil,
-	); err != nil {
-		return fmt.Errorf("set handle DACL on %s: %w", path, err)
-	}
+	f := os.NewFile(uintptr(handle), tmpPath)
+	committed := false
+	defer func() {
+		if !committed {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("write secure file %s: %w", path, err)
+		return fmt.Errorf("write tmp %s: %w", tmpPath, err)
 	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close tmp %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename tmp %s -> %s: %w", tmpPath, path, err)
+	}
+	committed = true
 	return nil
 }
 

--- a/pkg/secureperm/secureperm_windows_test.go
+++ b/pkg/secureperm/secureperm_windows_test.go
@@ -17,6 +17,7 @@
 package secureperm_test
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,25 +27,17 @@ import (
 	"github.com/cozystack/talm/pkg/secureperm"
 )
 
-// TestWriteFile_DACL_OwnerOnly confirms that WriteFile produces a
-// protected DACL (inheritance blocked) containing exactly one Allow ACE
-// for the current user SID. Without the DACL the file inherits
-// BUILTIN\Users from the parent — that is the whole point of the
-// Windows variant.
+// assertProtectedOwnerOnlyDACL reads the security descriptor back and
+// asserts it is structurally D:P(A;;FA;;;<current-user-SID>) — a
+// protected DACL with exactly one Allow ACE naming the current user.
+// The SDDL for a protected owner-only DACL looks like
 //
-// Assertion strategy: read the SDDL string of the security descriptor
-// and match structurally. The SDDL for a protected, owner-only DACL
-// looks like:  D:PAI(A;;FA;;;<USER-SID>)
-//   - "D:P" marks the DACL as protected (the PROTECTED flag we set)
-//   - "(A;" appears exactly once (one Allow ACE, no others)
-//   - the current user SID appears in that ACE
-func TestWriteFile_DACL_OwnerOnly(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "secret.txt")
-
-	if err := secureperm.WriteFile(path, []byte("x")); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+//	D:PAI(A;;FA;;;<USER-SID>)
+//
+// where "D:P" marks the DACL as protected, "(A;" prefixes an Allow
+// ACE, and the trailing SID names the trustee.
+func assertProtectedOwnerOnlyDACL(t *testing.T, path string) {
+	t.Helper()
 
 	sd, err := windows.GetNamedSecurityInfo(
 		path,
@@ -56,7 +49,6 @@ func TestWriteFile_DACL_OwnerOnly(t *testing.T) {
 	}
 	sddl := sd.String()
 
-	// Current user SID for the expected trustee.
 	var token windows.Token
 	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
 		t.Fatalf("OpenProcessToken: %v", err)
@@ -77,4 +69,56 @@ func TestWriteFile_DACL_OwnerOnly(t *testing.T) {
 	if !strings.Contains(sddl, wantSid) {
 		t.Errorf("DACL does not reference current user SID %q; SDDL=%q", wantSid, sddl)
 	}
+}
+
+// TestWriteFile_NewFile_DACL_Windows pins the happy path: a brand-new
+// file created by WriteFile ends up with a protected, owner-only DACL.
+func TestWriteFile_NewFile_DACL_Windows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+
+	if err := secureperm.WriteFile(path, []byte("x")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	assertProtectedOwnerOnlyDACL(t, path)
+}
+
+// TestWriteFile_Overwrite_DACL_Windows pins the fix for the CreateFile
+// + CREATE_ALWAYS + SECURITY_ATTRIBUTES gotcha: per MSDN, the
+// SECURITY_ATTRIBUTES descriptor is silently ignored when an existing
+// file is opened. If secureperm only relied on CreateFile to apply the
+// DACL then a pre-existing secrets.yaml left with a permissive
+// inherited DACL would stay permissive after rewrite. The fix
+// (SetSecurityInfo on the handle before writing bytes) must make the
+// post-write DACL protected and owner-only regardless of prior state.
+func TestWriteFile_Overwrite_DACL_Windows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pre-existing.txt")
+
+	// Seed the file via os.WriteFile — it inherits the TempDir DACL,
+	// which on a GitHub Actions runner typically includes BUILTIN\Users.
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := secureperm.WriteFile(path, []byte("new")); err != nil {
+		t.Fatalf("WriteFile (overwrite): %v", err)
+	}
+	assertProtectedOwnerOnlyDACL(t, path)
+}
+
+// TestLockDown_DACL_Windows mirrors the overwrite assertion for
+// LockDown alone — a file left permissive by some earlier process must
+// end up with a protected owner-only DACL after LockDown.
+func TestLockDown_DACL_Windows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "to-tighten.txt")
+
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := secureperm.LockDown(path); err != nil {
+		t.Fatalf("LockDown: %v", err)
+	}
+	assertProtectedOwnerOnlyDACL(t, path)
 }

--- a/pkg/secureperm/secureperm_windows_test.go
+++ b/pkg/secureperm/secureperm_windows_test.go
@@ -1,0 +1,80 @@
+//go:build windows
+
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureperm_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/cozystack/talm/pkg/secureperm"
+)
+
+// TestWriteFile_DACL_OwnerOnly confirms that WriteFile produces a
+// protected DACL (inheritance blocked) containing exactly one Allow ACE
+// for the current user SID. Without the DACL the file inherits
+// BUILTIN\Users from the parent — that is the whole point of the
+// Windows variant.
+//
+// Assertion strategy: read the SDDL string of the security descriptor
+// and match structurally. The SDDL for a protected, owner-only DACL
+// looks like:  D:PAI(A;;FA;;;<USER-SID>)
+//   - "D:P" marks the DACL as protected (the PROTECTED flag we set)
+//   - "(A;" appears exactly once (one Allow ACE, no others)
+//   - the current user SID appears in that ACE
+func TestWriteFile_DACL_OwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+
+	if err := secureperm.WriteFile(path, []byte("x")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo: %v", err)
+	}
+	sddl := sd.String()
+
+	// Current user SID for the expected trustee.
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		t.Fatalf("OpenProcessToken: %v", err)
+	}
+	defer func() { _ = token.Close() }()
+	tu, err := token.GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser: %v", err)
+	}
+	wantSid := tu.User.Sid.String()
+
+	if !strings.Contains(sddl, "D:P") {
+		t.Errorf("DACL is not protected (missing D:P flag); SDDL=%q", sddl)
+	}
+	if got := strings.Count(sddl, "(A;"); got != 1 {
+		t.Errorf("DACL has %d Allow ACEs, want exactly 1; SDDL=%q", got, sddl)
+	}
+	if !strings.Contains(sddl, wantSid) {
+		t.Errorf("DACL does not reference current user SID %q; SDDL=%q", wantSid, sddl)
+	}
+}

--- a/pkg/secureperm/secureperm_windows_test.go
+++ b/pkg/secureperm/secureperm_windows_test.go
@@ -83,14 +83,17 @@ func TestWriteFile_NewFile_DACL_Windows(t *testing.T) {
 	assertProtectedOwnerOnlyDACL(t, path)
 }
 
-// TestWriteFile_Overwrite_DACL_Windows pins the fix for the CreateFile
-// + CREATE_ALWAYS + SECURITY_ATTRIBUTES gotcha: per MSDN, the
-// SECURITY_ATTRIBUTES descriptor is silently ignored when an existing
-// file is opened. If secureperm only relied on CreateFile to apply the
-// DACL then a pre-existing secrets.yaml left with a permissive
-// inherited DACL would stay permissive after rewrite. The fix
-// (SetSecurityInfo on the handle before writing bytes) must make the
-// post-write DACL protected and owner-only regardless of prior state.
+// TestWriteFile_Overwrite_DACL_Windows pins that overwriting a
+// pre-existing file with a permissive inherited DACL leaves the
+// final on-disk file with a protected owner-only DACL. secureperm
+// achieves this via tmp + rename: the tmp is created fresh with
+// CREATE_NEW + SECURITY_ATTRIBUTES so its DACL is owner-only from
+// birth, and os.Rename on Windows (MoveFileEx with MOVEFILE_REPLACE_
+// EXISTING) carries the tmp's DACL over in place of whatever the
+// destination held. Any future regression — for example switching the
+// tmp to CREATE_ALWAYS, which silently ignores SECURITY_ATTRIBUTES,
+// or writing directly to the destination instead of renaming — would
+// cause this test to fail.
 func TestWriteFile_Overwrite_DACL_Windows(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pre-existing.txt")
@@ -105,6 +108,51 @@ func TestWriteFile_Overwrite_DACL_Windows(t *testing.T) {
 		t.Fatalf("WriteFile (overwrite): %v", err)
 	}
 	assertProtectedOwnerOnlyDACL(t, path)
+}
+
+// TestWriteFile_PreservesOriginalOnFailure_Windows asserts the atomic-
+// write contract on Windows: if the rename step fails, the original
+// file content is left intact. Secrets files are not reconstructible
+// — corrupting secrets.yaml costs the user a cluster PKI reissue.
+//
+// Failure is induced by setting FILE_ATTRIBUTE_READONLY on the
+// destination: MoveFileEx with MOVEFILE_REPLACE_EXISTING fails with
+// ERROR_ACCESS_DENIED against a read-only target, so os.Rename
+// returns an error and the deferred cleanup in WriteFile removes the
+// tmp. The original content must still be readable afterwards.
+func TestWriteFile_PreservesOriginalOnFailure_Windows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.yaml")
+
+	original := []byte("critical-content-DO-NOT-LOSE")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString: %v", err)
+	}
+	if err := windows.SetFileAttributes(pathUTF16, windows.FILE_ATTRIBUTE_READONLY); err != nil {
+		t.Fatalf("SetFileAttributes: %v", err)
+	}
+	t.Cleanup(func() {
+		// Drop the readonly flag so t.TempDir can clean up.
+		_ = windows.SetFileAttributes(pathUTF16, windows.FILE_ATTRIBUTE_NORMAL)
+	})
+
+	err = secureperm.WriteFile(path, []byte("replacement"))
+	if err == nil {
+		t.Fatal("expected WriteFile to fail when destination is read-only")
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("original file missing after failure: %v", readErr)
+	}
+	if string(got) != string(original) {
+		t.Errorf("original content corrupted on failure:\nwant %q\n got %q", original, got)
+	}
 }
 
 // TestLockDown_DACL_Windows mirrors the overwrite assertion for

--- a/pkg/secureperm/secureperm_windows_test.go
+++ b/pkg/secureperm/secureperm_windows_test.go
@@ -19,6 +19,7 @@ package secureperm_test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -26,6 +27,52 @@ import (
 
 	"github.com/cozystack/talm/pkg/secureperm"
 )
+
+// extractAllowACETrustee pulls the trustee string out of the first
+// Allow ACE in a SDDL string. SDDL ACE shape:
+//
+//	(ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid)
+//
+// The returned string may be a literal SID ("S-1-5-21-...") or a
+// well-known alias ("LA", "BA", "SY", ...) — caller feeds it to
+// windows.StringToSid which accepts both forms.
+func extractAllowACETrustee(sddl string) (string, error) {
+	re := regexp.MustCompile(`\(A;([^)]+)\)`)
+	m := re.FindStringSubmatch(sddl)
+	if len(m) < 2 {
+		return "", &sddlParseError{sddl: sddl, reason: "no Allow ACE"}
+	}
+	fields := strings.Split(m[1], ";")
+	// After the leading "A;" that lives in the regex literal, the inner
+	// fields are: ace_flags, rights, object_guid, inherit_object_guid,
+	// account_sid[, resource_attribute]. Minimum 5 fields.
+	if len(fields) < 5 {
+		return "", &sddlParseError{sddl: sddl, reason: "ACE has fewer than 5 fields"}
+	}
+	return fields[4], nil
+}
+
+type sddlParseError struct{ sddl, reason string }
+
+func (e *sddlParseError) Error() string { return e.reason + ": " + e.sddl }
+
+// assertTrusteeMatches resolves the ACE trustee string (literal SID or
+// SDDL alias) to a SID and compares to wantSid via EqualSid. SDDL
+// output on GitHub Actions runners returns the RID-500 admin as the
+// alias "LA" rather than the literal SID, so a string-contains check
+// against wantSid.String() is not robust. Resolving both sides to
+// canonical *SID and comparing with EqualSid is.
+func assertTrusteeMatches(t *testing.T, trusteeStr string, wantSid *windows.SID) {
+	t.Helper()
+	aceSid, err := windows.StringToSid(trusteeStr)
+	if err != nil {
+		t.Fatalf("StringToSid(%q): %v", trusteeStr, err)
+	}
+	if !windows.EqualSid(aceSid, wantSid) {
+		t.Errorf("ACE trustee %q (SID %s) != current user SID %s",
+			trusteeStr, aceSid.String(), wantSid.String())
+	}
+}
 
 // assertProtectedOwnerOnlyDACL reads the security descriptor back and
 // asserts it is structurally D:P(A;;FA;;;<current-user-SID>) — a
@@ -58,7 +105,6 @@ func assertProtectedOwnerOnlyDACL(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("GetTokenUser: %v", err)
 	}
-	wantSid := tu.User.Sid.String()
 
 	if !strings.Contains(sddl, "D:P") {
 		t.Errorf("DACL is not protected (missing D:P flag); SDDL=%q", sddl)
@@ -66,9 +112,11 @@ func assertProtectedOwnerOnlyDACL(t *testing.T, path string) {
 	if got := strings.Count(sddl, "(A;"); got != 1 {
 		t.Errorf("DACL has %d Allow ACEs, want exactly 1; SDDL=%q", got, sddl)
 	}
-	if !strings.Contains(sddl, wantSid) {
-		t.Errorf("DACL does not reference current user SID %q; SDDL=%q", wantSid, sddl)
+	trusteeStr, err := extractAllowACETrustee(sddl)
+	if err != nil {
+		t.Fatalf("extract trustee: %v", err)
 	}
+	assertTrusteeMatches(t, trusteeStr, tu.User.Sid)
 }
 
 // TestWriteFile_NewFile_DACL_Windows pins the happy path: a brand-new


### PR DESCRIPTION
## Summary

Close the Windows support loop. The original "template path with backslash" symptom was already fixed upstream of this branch (engine-side `NormalizeTemplatePath` in v0.22.0), but nothing proved it stayed fixed — CI only ran on Ubuntu, so the Windows-tagged tests never executed, and the release archive was a `.tar.gz` that stock Windows cannot open. This PR makes Windows a first-class target and closes the security gap that becomes visible once Windows users can actually run talm.

Closes #11

## What changes

### 1. Windows CI runner

`.github/workflows/pr.yml` runs `go test ./...` on both `ubuntu-latest` and `windows-latest` with `fail-fast: false`. The existing `engine_windows_test.go` (build-tagged `//go:build windows`) now actually executes. Any future regression in Windows-specific path handling fails CI.

### 2. Windows zip archives

`.goreleaser.yaml` uses `format_overrides` so Windows binaries ship as `.zip`. Linux and macOS remain `.tar.gz`.

### 3. Regression tests for backslash paths

Users running talm from PowerShell pass paths with `\` separators, which must be normalized before reaching the helm engine's forward-slash-only map keys. Both code paths that touch template arguments now have Windows-tagged tests:

- `apply_windows_test.go::TestResolveTemplatePaths_BackslashInput` covers `talm apply` via `resolveTemplatePaths`.
- `template_windows_test.go::TestResolveEngineTemplatePaths_BackslashInput` covers `talm template` via the newly-extracted `resolveEngineTemplatePaths`.

The two resolvers are intentionally different (apply resolves against `rootDir`, template against CWD with a `templates/<basename>` fallback), so they need separate coverage.

### 4. New `pkg/secureperm` package for sensitive files

A drop-in replacement for `os.WriteFile(path, data, 0o600)` and `os.Chmod(path, 0o600)`. On Unix it delegates to those calls with an explicit follow-up `Chmod` (required because `os.WriteFile` preserves prior mode bits on overwrite). On Windows it installs a protected NTFS DACL with a single Allow ACE for the current user SID.

WriteFile is also **atomic** on both platforms via write-to-tmp + rename — a failure mid-write leaves the original file intact. Secrets files are not reconstructible (corrupting `secrets.yaml` forces a cluster PKI reissue), so non-atomic writes are a real hazard.

Call sites migrated:

- `pkg/age/age.go` — `talm.key` creation, decrypted `secrets.yaml`, generic decrypted YAML.
- `pkg/commands/init.go` — talosconfig, secrets.yaml bundle (via the new `writeSecureToDestination` helper).
- `pkg/commands/rotate_ca_handler.go` — rotated `secrets.yaml`.
- `pkg/commands/talosconfig.go` — regenerated talosconfig.
- `pkg/commands/kubeconfig_handler.go` — kubeconfig tighten-after-fetch.
- `pkg/commands/template.go` — rendered machine config via `talm template --inplace` (embeds certs + PKI keys + cluster join tokens).

Tests cover the atomic-write contract on both OSes (`TestWriteFile_PreservesOriginalOnFailure_{Unix,Windows}`), the DACL shape on Windows (`TestWriteFile_*_DACL_Windows` parse the SDDL string and assert `D:P` + exactly one Allow ACE for the current user SID), overwrite-downgrade behavior on Unix (`TestWriteFile_OverwriteDowngrades_Unix`), and the new-file happy path on both.

### 5. Collateral cleanups

Three small defects surfaced while working in this area:

- `pkg/commands/kubeconfig_handler.go` had a vacuous `if err == nil { ... }` wrapper around the entire 60-line post-write block, guarding a condition that was already checked with early-return one line above. The wrapper also shadowed `err` with inner `filepath.Abs` assignments, making the outer variable meaningless. Removed.
- `pkg/commands/init.go::writeToDestination` printed `Created <path>` unconditionally after the write, so a permission failure produced a confusing "Created foo.key" + error pair. Both `writeToDestination` and the new `writeSecureToDestination` now gate the message on `err == nil`. Pinned by `TestWriteToDestination_SilentOnFailure` and `TestWriteToDestination_AnnouncesOnSuccess`.
- `writeSecretsBundleToFile` called `validateFileExists` twice — the outer call was redundant with the same check inside `writeSecureToDestination`. Removed.

### 6. README

New "Windows" installation subsection pointing at the release zip and documenting the `-t` / `--template` separator equivalence.

## Verification

- `go test ./...` on macOS — pass
- `GOOS=windows GOARCH=amd64 go build ./...` — clean
- `GOOS=windows GOARCH=amd64 go vet ./...` — clean
- `GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./...` — all test packages compile for Windows
- `golangci-lint run ./...` — 0 issues
- CI matrix (`ubuntu-latest` + `windows-latest`) is exercised by this PR itself — watch for `--- PASS` on both runners


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows platform support with installation docs and Windows-compatible template path handling.
  * Secure, cross-platform writing for sensitive outputs to ensure owner-only access.

* **Bug Fixes**
  * Consistent permission/ACL tightening for secret files across platforms.

* **Tests**
  * Expanded Unix and Windows tests covering permission, overwrite, and path-resolution behaviors.

* **Chores**
  * CI matrix expanded to include Windows; release/archive formats and dependency declarations updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->