### PR TITLE
fix(chart): discovery-based defaults for subnets; required endpoint and VIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,22 @@ automatically from the node's default-gateway-bearing link, so no
 override is needed unless you have a multi-homed node that requires
 a specific subnet pinned.
 
-Boot Talos Linux node, let's say it has address `1.2.3.4`. Then:
+Boot Talos Linux node, let's say it has address `192.0.2.4`. Then:
 
 ```yaml
-# values.yaml (single-node example matching the 1.2.3.4 node below)
-endpoint: "https://1.2.3.4:6443"
+# values.yaml (single-node example matching the 192.0.2.4 node below)
+endpoint: "https://192.0.2.4:6443"
 floatingIP: ""
 ```
 
 Gather node information:
 ```bash
-talm -n 1.2.3.4 -e 1.2.3.4 template -t templates/controlplane.yaml -i > nodes/node1.yaml
+talm -n 192.0.2.4 -e 192.0.2.4 template -t templates/controlplane.yaml -i > nodes/node1.yaml
 ```
 
 Edit `nodes/node1.yaml` file:
 ```yaml
-# talm: nodes=["1.2.3.4"], endpoints=["1.2.3.4"], templates=["templates/controlplane.yaml"]
+# talm: nodes=["192.0.2.4"], endpoints=["192.0.2.4"], templates=["templates/controlplane.yaml"]
 machine:
     network:
         # -- Discovered interfaces:
@@ -108,10 +108,10 @@ machine:
         interfaces:
             - interface: enx9c6b0047066c
               addresses:
-                - 1.2.3.4/26
+                - 192.0.2.4/26
               routes:
                 - network: 0.0.0.0/0
-                  gateway: 1.2.3.1
+                  gateway: 192.0.2.1
         nameservers:
             - 8.8.8.8
             - 8.8.4.4
@@ -132,7 +132,7 @@ machine:
 cluster:
     clusterName: talm
     controlPlane:
-        endpoint: https://192.168.0.1:6443
+        endpoint: https://192.0.2.4:6443
 ```
 
 > **Note:** The output format depends on the Talos version configured in `Chart.yaml` (`templateOptions.talosVersion`) or via the `--talos-version` CLI flag.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ cd newcluster
 talm init -p cozystack -N myawesomecluster
 ```
 
+Edit `values.yaml` to set your cluster's control-plane endpoint — the
+URL every node's kubelet and kube-proxy will dial. The chart leaves
+it empty on purpose so a missed override fails loudly instead of
+silently embedding a placeholder. For cozystack deployments set
+`endpoint` and `floatingIP` together (same IP, single VIP); for
+single-node clusters use that node's routable IP; for multi-node
+with an external load balancer use the LB URL. Subnet-selector
+fields (`kubelet.validSubnets`, `etcd.advertisedSubnets`) are derived
+automatically from the node's default-gateway-bearing link — no
+override needed unless you have a multi-homed node that requires a
+specific subnet pinned.
+
+```yaml
+# values.yaml
+endpoint: "https://192.168.0.1:6443"
+floatingIP: 192.168.0.1
+```
+
 Boot Talos Linux node, let's say it has address `1.2.3.4`
 
 Gather node information:

--- a/README.md
+++ b/README.md
@@ -59,25 +59,26 @@ cd newcluster
 talm init -p cozystack -N myawesomecluster
 ```
 
-Edit `values.yaml` to set your cluster's control-plane endpoint — the
-URL every node's kubelet and kube-proxy will dial. The chart leaves
-it empty on purpose so a missed override fails loudly instead of
-silently embedding a placeholder. For cozystack deployments set
-`endpoint` and `floatingIP` together (same IP, single VIP); for
-single-node clusters use that node's routable IP; for multi-node
-with an external load balancer use the LB URL. Subnet-selector
-fields (`kubelet.validSubnets`, `etcd.advertisedSubnets`) are derived
-automatically from the node's default-gateway-bearing link — no
-override needed unless you have a multi-homed node that requires a
-specific subnet pinned.
+Edit `values.yaml` to set your cluster's control-plane endpoint. This
+is the URL every node's kubelet and kube-proxy will dial. The chart
+leaves it empty on purpose so a missed override fails loudly instead
+of silently embedding a placeholder. For cozystack VIP setups set
+`endpoint` and `floatingIP` together (same IP, single shared VIP);
+for single-node clusters use that node's routable IP and leave
+`floatingIP` blank; for multi-node with an external load balancer
+use the LB URL and leave `floatingIP` blank. Subnet-selector fields
+(`kubelet.validSubnets`, `etcd.advertisedSubnets`) are derived
+automatically from the node's default-gateway-bearing link, so no
+override is needed unless you have a multi-homed node that requires
+a specific subnet pinned.
+
+Boot Talos Linux node, let's say it has address `1.2.3.4`. Then:
 
 ```yaml
-# values.yaml
-endpoint: "https://192.168.0.1:6443"
-floatingIP: 192.168.0.1
+# values.yaml (single-node example matching the 1.2.3.4 node below)
+endpoint: "https://1.2.3.4:6443"
+floatingIP: ""
 ```
-
-Boot Talos Linux node, let's say it has address `1.2.3.4`
 
 Gather node information:
 ```bash

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -18,7 +18,14 @@ machine:
   kubelet:
     nodeIP:
       validSubnets:
+        {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
+        {{- else }}
+        {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+        {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+        - {{ . }}
+        {{- end }}
+        {{- end }}
     extraConfig:
       cpuManagerPolicy: static
       maxPods: 512

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -21,15 +21,22 @@ machine:
         {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
         {{- else }}
-        {{- /* Fall back to the subnet of the node's default-gateway-bearing link.
-               cidrNetwork masks host bits so the emitted YAML is the canonical
-               network form (192.168.201.0/24) rather than host-form (192.168.201.10/24). */ -}}
+        {{- /* Fall back to the subnet of the node's default-gateway-bearing
+               link. cidrNetwork masks host bits so the emitted YAML is the
+               canonical network form (192.168.201.0/24) rather than the
+               host form (192.168.201.10/24). Dedupe after masking because
+               a link with a secondary address in the same subnet would
+               otherwise produce duplicate list entries. */ -}}
         {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
         {{- if not $addrs }}
-        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery — no default-gateway-bearing link was found on the node. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
         {{- end }}
+        {{- $subnets := list }}
         {{- range $addrs }}
-        - {{ . | cidrNetwork }}
+        {{- $subnets = append $subnets (. | cidrNetwork) }}
+        {{- end }}
+        {{- range uniq $subnets }}
+        - {{ . }}
         {{- end }}
         {{- end }}
     extraConfig:
@@ -98,7 +105,7 @@ cluster:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
   clusterName: "{{ .Chart.Name }}"
   controlPlane:
-    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane endpoint (e.g. https://<vip>:6443); no auto-discovery is possible because this is a cluster-wide value, not a per-node one" .Values.endpoint | quote }}
+    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP (cozystack floatingIP) or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}
   allowSchedulingOnControlPlanes: true
   controllerManager:
@@ -135,13 +142,18 @@ cluster:
       {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
       {{- else }}
-      {{- /* Fall back to the subnet of the node's default-gateway-bearing link;
-             cidrNetwork masks host bits to emit canonical network form. Empty
-             discovery already errored earlier in the template via validSubnets'
-             required() guard, so we reach this block only when at least one
-             address was resolved. */ -}}
+      {{- /* Fall back to the subnet of the node's default-gateway-bearing
+             link; cidrNetwork masks host bits to emit canonical network
+             form. Dedupe handled the same way as validSubnets above.
+             Empty discovery already errored via validSubnets' required()
+             guard, so we reach this block only when at least one address
+             was resolved. */ -}}
+      {{- $subnets := list }}
       {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-      - {{ . | cidrNetwork }}
+      {{- $subnets = append $subnets (. | cidrNetwork) }}
+      {{- end }}
+      {{- range uniq $subnets }}
+      - {{ . }}
       {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -126,7 +126,14 @@ cluster:
     enabled: false
   etcd:
     advertisedSubnets:
+      {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
+      {{- else }}
+      {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+      {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+      - {{ . }}
+      {{- end }}
+      {{- end }}
   {{- end }}
 {{- end }}
 

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -92,7 +92,7 @@ cluster:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
   clusterName: "{{ .Chart.Name }}"
   controlPlane:
-    endpoint: "{{ .Values.endpoint }}"
+    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane endpoint (e.g. https://<vip>:6443); no auto-discovery is possible because this is a cluster-wide value, not a per-node one" .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}
   allowSchedulingOnControlPlanes: true
   controllerManager:

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -21,9 +21,15 @@ machine:
         {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
         {{- else }}
-        {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
-        {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-        - {{ . }}
+        {{- /* Fall back to the subnet of the node's default-gateway-bearing link.
+               cidrNetwork masks host bits so the emitted YAML is the canonical
+               network form (192.168.201.0/24) rather than host-form (192.168.201.10/24). */ -}}
+        {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+        {{- if not $addrs }}
+        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery — no default-gateway-bearing link was found on the node. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- end }}
+        {{- range $addrs }}
+        - {{ . | cidrNetwork }}
         {{- end }}
         {{- end }}
     extraConfig:
@@ -129,9 +135,13 @@ cluster:
       {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
       {{- else }}
-      {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+      {{- /* Fall back to the subnet of the node's default-gateway-bearing link;
+             cidrNetwork masks host bits to emit canonical network form. Empty
+             discovery already errored earlier in the template via validSubnets'
+             required() guard, so we reach this block only when at least one
+             address was resolved. */ -}}
       {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-      - {{ . }}
+      - {{ . | cidrNetwork }}
       {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -29,7 +29,7 @@ machine:
                otherwise produce duplicate list entries. */ -}}
         {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
         {{- if not $addrs }}
-        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- fail "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." }}
         {{- end }}
         {{- $subnets := list }}
         {{- range $addrs }}

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -1,4 +1,10 @@
+# REQUIRED. Cluster control-plane endpoint. No auto-discovery — this
+# is a cluster-wide value that every node's kubelet and kube-proxy
+# dials, not a per-node one. For cozystack deployments set it to the
+# floatingIP below; for single-node clusters set it to that node's
+# routable IP; for external load balancers use the LB's URL.
 endpoint: "https://192.168.100.10:6443"
+
 clusterDomain: cozy.local
 floatingIP: 192.168.100.10
 image: "ghcr.io/cozystack/cozystack/talos:v1.12.6"
@@ -6,8 +12,17 @@ podSubnets:
 - 10.244.0.0/16
 serviceSubnets:
 - 10.96.0.0/16
-advertisedSubnets:
-- 192.168.100.0/24
+
+# Optional override for machine.kubelet.nodeIP.validSubnets and
+# cluster.etcd.advertisedSubnets. When left empty the chart derives
+# the value from the node's default-gateway-bearing link at render
+# time (via talm.discovered.default_addresses_by_gateway), so the
+# generated machine config matches the node's actual network without
+# any values.yaml edit. Set this only when you want to pin a specific
+# subnet — typically for multi-homed nodes where the default-gateway
+# link is not the subnet you want kubelet/etcd to use.
+advertisedSubnets: []
+
 oidcIssuerUrl: ""
 certSANs: []
 nr_hugepages: 0

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -1,9 +1,13 @@
-# REQUIRED. Cluster control-plane endpoint. No auto-discovery — this
+# REQUIRED. Cluster control-plane endpoint. Left empty intentionally
+# so the chart's `required` check fires loudly on a fresh install —
+# a placeholder default would silently embed a broken endpoint in
+# every rendered machine config. No auto-discovery is possible: this
 # is a cluster-wide value that every node's kubelet and kube-proxy
 # dials, not a per-node one. For cozystack deployments set it to the
 # floatingIP below; for single-node clusters set it to that node's
 # routable IP; for external load balancers use the LB's URL.
-endpoint: "https://192.168.100.10:6443"
+# Example: endpoint: "https://192.168.100.10:6443"
+endpoint: ""
 
 clusterDomain: cozy.local
 floatingIP: 192.168.100.10
@@ -21,6 +25,9 @@ serviceSubnets:
 # any values.yaml edit. Set this only when you want to pin a specific
 # subnet — typically for multi-homed nodes where the default-gateway
 # link is not the subnet you want kubelet/etcd to use.
+# Example:
+#   advertisedSubnets:
+#     - "10.0.0.0/8"
 advertisedSubnets: []
 
 oidcIssuerUrl: ""

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -1,28 +1,34 @@
 # REQUIRED. Cluster control-plane endpoint. Left empty intentionally
-# so the chart's `required` check fires loudly on a fresh install —
-# a placeholder default would silently embed a broken endpoint in
+# so the chart's `required` check fires loudly on a fresh install.
+# A placeholder default would silently embed a broken endpoint in
 # every rendered machine config. No auto-discovery is possible: this
 # is a cluster-wide value that every node's kubelet and kube-proxy
 # dials, not a per-node one.
 #
-# For cozystack deployments, set `endpoint` AND `floatingIP` below
-# to the SAME IP — floatingIP drives the per-node VIP (Layer2VIPConfig)
-# that endpoint points at. Leaving them mismatched produces a cluster
+# For cozystack VIP setups, set `endpoint` AND `floatingIP` below to
+# the SAME IP. floatingIP drives the per-node VIP (Layer2VIPConfig)
+# that endpoint points at; leaving them mismatched produces a cluster
 # that talks to an IP no node actually claims.
 #
 # For single-node clusters without a VIP, set `endpoint` to that
-# node's routable IP and blank out `floatingIP` below.
+# node's routable IP and leave `floatingIP` blank.
 #
 # For multi-node with an external load balancer, set `endpoint` to
-# the LB URL and blank out `floatingIP`.
+# the LB URL and leave `floatingIP` blank.
 #
-# Example: endpoint: "https://192.168.100.10:6443"
+# Example: endpoint: "https://192.168.0.1:6443"
 endpoint: ""
 
 clusterDomain: cozy.local
-# REQUIRED for cozystack VIP setups (must equal `endpoint` host).
-# Set to "" to disable the VIP (single-node or external LB scenarios).
-floatingIP: 192.168.100.10
+# Layer-2 VIP for cozystack multi-node setups. When set, the chart
+# emits a Layer2VIPConfig document pinning this IP as a floating
+# address on the node's primary link. MUST equal the host portion
+# of `endpoint` above, otherwise the cluster dials an IP that no
+# node actually claims. Blank by default so the shipped value never
+# silently embeds a wrong VIP -- fill in only if you want a VIP.
+# Single-node clusters and external-LB topologies leave it blank.
+# Example: floatingIP: 192.168.0.1
+floatingIP: ""
 image: "ghcr.io/cozystack/cozystack/talos:v1.12.6"
 podSubnets:
 - 10.244.0.0/16

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -3,13 +3,25 @@
 # a placeholder default would silently embed a broken endpoint in
 # every rendered machine config. No auto-discovery is possible: this
 # is a cluster-wide value that every node's kubelet and kube-proxy
-# dials, not a per-node one. For cozystack deployments set it to the
-# floatingIP below; for single-node clusters set it to that node's
-# routable IP; for external load balancers use the LB's URL.
+# dials, not a per-node one.
+#
+# For cozystack deployments, set `endpoint` AND `floatingIP` below
+# to the SAME IP — floatingIP drives the per-node VIP (Layer2VIPConfig)
+# that endpoint points at. Leaving them mismatched produces a cluster
+# that talks to an IP no node actually claims.
+#
+# For single-node clusters without a VIP, set `endpoint` to that
+# node's routable IP and blank out `floatingIP` below.
+#
+# For multi-node with an external load balancer, set `endpoint` to
+# the LB URL and blank out `floatingIP`.
+#
 # Example: endpoint: "https://192.168.100.10:6443"
 endpoint: ""
 
 clusterDomain: cozy.local
+# REQUIRED for cozystack VIP setups (must equal `endpoint` host).
+# Set to "" to disable the VIP (single-node or external LB scenarios).
 floatingIP: 192.168.100.10
 image: "ghcr.io/cozystack/cozystack/talos:v1.12.6"
 podSubnets:

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -49,7 +49,14 @@ cluster:
     {{- end }}
   etcd:
     advertisedSubnets:
+      {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
+      {{- else }}
+      {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+      {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+      - {{ . }}
+      {{- end }}
+      {{- end }}
   {{- end }}
 {{- end }}
 

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -24,7 +24,7 @@ machine:
                otherwise produce duplicate list entries. */ -}}
         {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
         {{- if not $addrs }}
-        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- fail "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." }}
         {{- end }}
         {{- $subnets := list }}
         {{- range $addrs }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -13,7 +13,14 @@ machine:
   kubelet:
     nodeIP:
       validSubnets:
+        {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
+        {{- else }}
+        {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+        {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+        - {{ . }}
+        {{- end }}
+        {{- end }}
   {{- with .Values.certSANs }}
   certSANs:
   {{- toYaml . | nindent 2 }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -16,9 +16,15 @@ machine:
         {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
         {{- else }}
-        {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
-        {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-        - {{ . }}
+        {{- /* Fall back to the subnet of the node's default-gateway-bearing link.
+               cidrNetwork masks host bits so the emitted YAML is the canonical
+               network form (192.168.201.0/24) rather than host-form (192.168.201.10/24). */ -}}
+        {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
+        {{- if not $addrs }}
+        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery — no default-gateway-bearing link was found on the node. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- end }}
+        {{- range $addrs }}
+        - {{ . | cidrNetwork }}
         {{- end }}
         {{- end }}
   {{- with .Values.certSANs }}
@@ -52,9 +58,13 @@ cluster:
       {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
       {{- else }}
-      {{- /* Fall back to the CIDR of the node's default-gateway-bearing link. */ -}}
+      {{- /* Fall back to the subnet of the node's default-gateway-bearing link;
+             cidrNetwork masks host bits to emit canonical network form. Empty
+             discovery already errored earlier in the template via validSubnets'
+             required() guard, so we reach this block only when at least one
+             address was resolved. */ -}}
       {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-      - {{ . }}
+      - {{ . | cidrNetwork }}
       {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -40,7 +40,7 @@ cluster:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
   clusterName: "{{ .Chart.Name }}"
   controlPlane:
-    endpoint: "{{ .Values.endpoint }}"
+    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane endpoint (e.g. https://<vip>:6443); no auto-discovery is possible because this is a cluster-wide value, not a per-node one" .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}
   apiServer:
     {{- with .Values.certSANs }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -16,15 +16,22 @@ machine:
         {{- if .Values.advertisedSubnets }}
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
         {{- else }}
-        {{- /* Fall back to the subnet of the node's default-gateway-bearing link.
-               cidrNetwork masks host bits so the emitted YAML is the canonical
-               network form (192.168.201.0/24) rather than host-form (192.168.201.10/24). */ -}}
+        {{- /* Fall back to the subnet of the node's default-gateway-bearing
+               link. cidrNetwork masks host bits so the emitted YAML is the
+               canonical network form (192.168.201.0/24) rather than the
+               host form (192.168.201.10/24). Dedupe after masking because
+               a link with a secondary address in the same subnet would
+               otherwise produce duplicate list entries. */ -}}
         {{- $addrs := fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
         {{- if not $addrs }}
-        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery — no default-gateway-bearing link was found on the node. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
+        {{- required "values.yaml: `advertisedSubnets` was left empty and talm could not derive a default from discovery. No default-gateway-bearing link was found on the node. This field is a cluster-wide subnet selector fed to kubelet and etcd; `talm template` is invoked once per node and cannot merge per-node values into one cluster value. Either set advertisedSubnets explicitly in values.yaml, or ensure the node has a default route before running `talm template`." "" }}
         {{- end }}
+        {{- $subnets := list }}
         {{- range $addrs }}
-        - {{ . | cidrNetwork }}
+        {{- $subnets = append $subnets (. | cidrNetwork) }}
+        {{- end }}
+        {{- range uniq $subnets }}
+        - {{ . }}
         {{- end }}
         {{- end }}
   {{- with .Values.certSANs }}
@@ -46,7 +53,7 @@ cluster:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
   clusterName: "{{ .Chart.Name }}"
   controlPlane:
-    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane endpoint (e.g. https://<vip>:6443); no auto-discovery is possible because this is a cluster-wide value, not a per-node one" .Values.endpoint | quote }}
+    endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}
   apiServer:
     {{- with .Values.certSANs }}
@@ -58,13 +65,18 @@ cluster:
       {{- if .Values.advertisedSubnets }}
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
       {{- else }}
-      {{- /* Fall back to the subnet of the node's default-gateway-bearing link;
-             cidrNetwork masks host bits to emit canonical network form. Empty
-             discovery already errored earlier in the template via validSubnets'
-             required() guard, so we reach this block only when at least one
-             address was resolved. */ -}}
+      {{- /* Fall back to the subnet of the node's default-gateway-bearing
+             link; cidrNetwork masks host bits to emit canonical network
+             form. Dedupe handled the same way as validSubnets above.
+             Empty discovery already errored via validSubnets' required()
+             guard, so we reach this block only when at least one address
+             was resolved. */ -}}
+      {{- $subnets := list }}
       {{- range fromJsonArray (include "talm.discovered.default_addresses_by_gateway" .) }}
-      - {{ . | cidrNetwork }}
+      {{- $subnets = append $subnets (. | cidrNetwork) }}
+      {{- end }}
+      {{- range uniq $subnets }}
+      - {{ . }}
       {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -1,11 +1,11 @@
 # REQUIRED. Cluster control-plane endpoint. Left empty intentionally
-# so the chart's `required` check fires loudly on a fresh install —
-# a placeholder default would silently embed a broken endpoint in
+# so the chart's `required` check fires loudly on a fresh install.
+# A placeholder default would silently embed a broken endpoint in
 # every rendered machine config. No auto-discovery is possible: this
 # is a cluster-wide value that every node's kubelet and kube-proxy
 # dials, not a per-node one. For single-node clusters set it to that
 # node's routable IP; for multi-node set it to a VIP or external LB.
-# Example: endpoint: "https://192.168.100.10:6443"
+# Example: endpoint: "https://192.168.0.1:6443"
 endpoint: ""
 
 podSubnets:

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -1,8 +1,22 @@
+# REQUIRED. Cluster control-plane endpoint. No auto-discovery — this
+# is a cluster-wide value that every node's kubelet and kube-proxy
+# dials, not a per-node one. For single-node clusters set it to that
+# node's routable IP; for multi-node set it to a VIP or external LB.
 endpoint: "https://192.168.100.10:6443"
+
 podSubnets:
 - 10.244.0.0/16
 serviceSubnets:
 - 10.96.0.0/16
-advertisedSubnets:
-- 192.168.100.0/24
+
+# Optional override for machine.kubelet.nodeIP.validSubnets and
+# cluster.etcd.advertisedSubnets. When left empty the chart derives
+# the value from the node's default-gateway-bearing link at render
+# time (via talm.discovered.default_addresses_by_gateway), so the
+# generated machine config matches the node's actual network without
+# any values.yaml edit. Set this only when you want to pin a specific
+# subnet — typically for multi-homed nodes where the default-gateway
+# link is not the subnet you want kubelet/etcd to use.
+advertisedSubnets: []
+
 certSANs: []

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -1,8 +1,12 @@
-# REQUIRED. Cluster control-plane endpoint. No auto-discovery — this
+# REQUIRED. Cluster control-plane endpoint. Left empty intentionally
+# so the chart's `required` check fires loudly on a fresh install —
+# a placeholder default would silently embed a broken endpoint in
+# every rendered machine config. No auto-discovery is possible: this
 # is a cluster-wide value that every node's kubelet and kube-proxy
 # dials, not a per-node one. For single-node clusters set it to that
 # node's routable IP; for multi-node set it to a VIP or external LB.
-endpoint: "https://192.168.100.10:6443"
+# Example: endpoint: "https://192.168.100.10:6443"
+endpoint: ""
 
 podSubnets:
 - 10.244.0.0/16
@@ -17,6 +21,9 @@ serviceSubnets:
 # any values.yaml edit. Set this only when you want to pin a specific
 # subnet — typically for multi-homed nodes where the default-gateway
 # link is not the subnet you want kubelet/etcd to use.
+# Example:
+#   advertisedSubnets:
+#     - "10.0.0.0/8"
 advertisedSubnets: []
 
 certSANs: []

--- a/pkg/engine/helm/engine.go
+++ b/pkg/engine/helm/engine.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"fmt"
 	"log"
+	"net/netip"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -216,6 +217,19 @@ func (e Engine) initFunMap(t *template.Template) {
 		funcMap["getHostByName"] = func(name string) string {
 			return ""
 		}
+	}
+
+	// cidrNetwork canonicalizes a CIDR string to its network form
+	// ("192.168.201.10/24" -> "192.168.201.0/24"), matching what
+	// operators see in Talos docs and upstream examples. Sprig ships
+	// no equivalent; net/netip's ParsePrefix + Masked handles both
+	// IPv4 and IPv6 without any host-bit arithmetic in the template.
+	funcMap["cidrNetwork"] = func(cidr string) (string, error) {
+		p, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return "", fmt.Errorf("cidrNetwork: %w", err)
+		}
+		return p.Masked().String(), nil
 	}
 
 	t.Funcs(funcMap)

--- a/pkg/engine/helm/engine_test.go
+++ b/pkg/engine/helm/engine_test.go
@@ -1218,3 +1218,56 @@ func TestTalosVersionConcurrentRender(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestCidrNetworkTemplateFunc exercises the cidrNetwork template
+// function directly (bypassing chart rendering) so a future refactor
+// that breaks parsing or masking — for either IPv4 or IPv6 inputs —
+// is caught without needing to boot the whole helm engine.
+func TestCidrNetworkTemplateFunc(t *testing.T) {
+	renderExpr := func(expr string) (string, error) {
+		chrt := &chart.Chart{
+			Metadata:  &chart.Metadata{Name: "cidrtest"},
+			Templates: []*chart.File{{Name: "templates/out.yaml", Data: []byte(expr)}},
+			Values:    map[string]any{},
+		}
+		var eng Engine
+		out, err := eng.Render(chrt, chartutil.Values{"Values": map[string]any{}})
+		if err != nil {
+			return "", err
+		}
+		return out["cidrtest/templates/out.yaml"], nil
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"ipv4 host form", "192.168.201.10/24", "192.168.201.0/24", false},
+		{"ipv4 already canonical", "10.0.0.0/8", "10.0.0.0/8", false},
+		{"ipv4 narrow prefix", "192.168.201.10/31", "192.168.201.10/31", false},
+		{"ipv6 host form", "2001:db8::1/64", "2001:db8::/64", false},
+		{"ipv6 already canonical", "fd00::/8", "fd00::/8", false},
+		{"malformed missing prefix", "192.168.201.10", "", true},
+		{"malformed garbage", "not-a-cidr", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderExpr(fmt.Sprintf(`{{ cidrNetwork %q }}`, tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for input %q, got output %q", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("cidrNetwork(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -1444,8 +1444,15 @@ func TestMultiDocCozystack_EmptyDiscoveryErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected required() error when advertisedSubnets is empty and discovery yields nothing")
 	}
+	// Assert on both the user-facing field name and the diagnostic
+	// phrase about the default route — two independent substrings
+	// that together pin the guidance the error is supposed to deliver.
+	// If a future reword drops either signal, this test catches it.
 	if !strings.Contains(err.Error(), "advertisedSubnets") {
-		t.Errorf("error should mention advertisedSubnets / default route; got: %v", err)
+		t.Errorf("error should mention advertisedSubnets field; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "default route") {
+		t.Errorf("error should mention 'default route' remediation; got: %v", err)
 	}
 }
 

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -261,10 +261,12 @@ func TestMultiDocCozystack_ControlPlane(t *testing.T) {
 	assertContains(t, output, "kind: RegistryMirrorConfig")
 	assertContains(t, output, "https://mirror.gcr.io")
 
-	// Multi-doc: Layer2VIPConfig emitted for controlplane when floatingIP is
-	// set in values (cozystack default: 192.168.100.10).
-	assertContains(t, output, "kind: Layer2VIPConfig")
-	assertContains(t, output, "192.168.100.10")
+	// Multi-doc: Layer2VIPConfig is gated on floatingIP, which is now
+	// blank in the shipped cozystack values.yaml (see
+	// TestMultiDocCozystack_Layer2VIPConfigWhenFloatingIPSet for the
+	// emitted-when-set path). Absence here asserts the chart does not
+	// fall back to a placeholder VIP on a fresh install.
+	assertNotContains(t, output, "kind: Layer2VIPConfig")
 
 	// Multi-doc: network interface document present (LinkConfig or BondConfig)
 	hasLinkConfig := strings.Contains(output, "kind: LinkConfig")
@@ -1305,6 +1307,110 @@ func TestMultiDocCozystack_ShippedDefaultsFailFresh(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "endpoint") {
 		t.Errorf("error should mention 'endpoint'; got: %v", err)
+	}
+}
+
+// TestMultiDocCozystack_Layer2VIPConfigWhenFloatingIPSet pins that
+// the VIP path still works when the operator explicitly sets
+// floatingIP — the fix for the shipped-placeholder bug blanked the
+// default but must not break the VIP feature itself.
+func TestMultiDocCozystack_Layer2VIPConfigWhenFloatingIPSet(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{
+		"floatingIP": "192.168.201.5",
+	})
+
+	assertContains(t, result, "kind: Layer2VIPConfig")
+	assertContains(t, result, `"192.168.201.5"`)
+}
+
+// TestMultiDocCozystack_NoVIPOnFreshDefaults asserts the corollary:
+// a fresh install keeps floatingIP blank, so Layer2VIPConfig must not
+// appear. This is the regression guard for the shipped-placeholder
+// fix — any future commit that re-introduces a non-empty floatingIP
+// default fails this test.
+func TestMultiDocCozystack_NoVIPOnFreshDefaults(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{})
+
+	assertNotContains(t, result, "kind: Layer2VIPConfig")
+}
+
+// TestMultiDocCozystack_DedupesDuplicateSubnetsFromMultipleAddresses
+// pins that a link with multiple addresses in the same subnet emits
+// a single entry in validSubnets / advertisedSubnets, not one entry
+// per address. validSubnets is a set semantically, so duplicates are
+// noise that churns config diffs.
+func TestMultiDocCozystack_DedupesDuplicateSubnetsFromMultipleAddresses(t *testing.T) {
+	// Lookup fixture: two addresses on eth0 in the same /24.
+	multiAddrLookup := func() func(string, string, string) (map[string]any, error) {
+		eth0 := map[string]any{
+			"metadata": map[string]any{"id": "eth0"},
+			"spec": map[string]any{
+				"kind":         "physical",
+				"index":        1,
+				"hardwareAddr": "aa:bb:cc:00:00:01",
+				"busPath":      "pci-0000:00:1f.0",
+			},
+		}
+		routesList := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items": []any{
+				map[string]any{
+					"spec": map[string]any{
+						"dst": "", "gateway": "192.168.201.1",
+						"outLinkName": "eth0", "family": "inet4", "table": "main",
+					},
+				},
+			},
+		}
+		addressesList := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items": []any{
+				map[string]any{"spec": map[string]any{
+					"linkName": "eth0", "address": "192.168.201.10/24",
+					"family": "inet4", "scope": "global",
+				}},
+				map[string]any{"spec": map[string]any{
+					"linkName": "eth0", "address": "192.168.201.11/24",
+					"family": "inet4", "scope": "global",
+				}},
+			},
+		}
+		return func(resource, namespace, id string) (map[string]any, error) {
+			switch resource {
+			case "routes":
+				return routesList, nil
+			case "links":
+				if id == "eth0" {
+					return eth0, nil
+				}
+				if id == "" {
+					return map[string]any{"apiVersion": "v1", "kind": "List", "items": []any{eth0}}, nil
+				}
+			case "addresses":
+				return addressesList, nil
+			case "nodeaddress":
+				if id == "default" {
+					return map[string]any{"spec": map[string]any{"addresses": []any{"192.168.201.10/24"}}}, nil
+				}
+			case "resolvers":
+				if id == "resolvers" {
+					return map[string]any{"spec": map[string]any{"dnsServers": []any{"8.8.8.8"}}}, nil
+				}
+			}
+			return map[string]any{}, nil
+		}
+	}()
+
+	result := renderCozystackWith(t, multiAddrLookup, map[string]any{
+		"advertisedSubnets": []any{},
+	})
+
+	// Two addresses in the same subnet must collapse to one list entry.
+	if got := strings.Count(result, "- 192.168.201.0/24"); got != 2 {
+		// Expected: 1 in validSubnets + 1 in advertisedSubnets = 2 total.
+		t.Errorf("expected canonical subnet 192.168.201.0/24 to appear exactly 2 times (once each in validSubnets and advertisedSubnets), got %d:\n%s", got, result)
 	}
 }
 

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -42,6 +42,40 @@ const testEndpoint = "https://talm-test.invalid:6443"
 // advertisedSubnets explicitly.
 const testAdvertisedSubnet = "192.168.1.0/24"
 
+// cloneValues returns a recursive deep copy of the chart values map.
+// maps.Copy is a shallow copy — mutating a nested map or slice in a
+// test would leak into chrt.Values and corrupt subsequent renders.
+// Since chart values consist only of maps, slices, and primitives,
+// a small switch + recursion suffices; no external dep needed.
+func cloneValues(src map[string]any) map[string]any {
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = deepClone(v)
+	}
+	return dst
+}
+
+func deepClone(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = deepClone(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = deepClone(vv)
+		}
+		return out
+	default:
+		// Primitives (string, bool, int, float, nil) are immutable —
+		// safe to share.
+		return v
+	}
+}
+
 // renderChartTemplate renders a chart template in offline mode and returns the output.
 // talosVersion sets the TalosVersion in the Helm engine context (empty string for legacy).
 func renderChartTemplate(t *testing.T, chartPath string, templateFile string, talosVersion ...string) string {
@@ -66,9 +100,9 @@ func renderChartTemplate(t *testing.T, chartPath string, templateFile string, ta
 	// for cozystack and generic presets post-issue-25 fix). Tests
 	// that specifically exercise the required-endpoint or empty-
 	// discovery guards build their own values maps and do not go
-	// through this helper.
-	values := make(map[string]any)
-	maps.Copy(values, chrt.Values)
+	// through this helper. cloneValues deep-copies so a mutation
+	// here never leaks into chrt.Values.
+	values := cloneValues(chrt.Values)
 	if v, _ := values["endpoint"].(string); v == "" {
 		values["endpoint"] = testEndpoint
 	}
@@ -1116,8 +1150,10 @@ func renderCozystackWith(t *testing.T, lookup func(string, string, string) (map[
 	if err != nil {
 		t.Fatalf("load chart: %v", err)
 	}
-	values := make(map[string]any)
-	maps.Copy(values, chrt.Values)
+	// Deep-copy chart values so mutations in this helper (or in the
+	// caller's overrides) never leak into chrt.Values and corrupt
+	// subsequent renders.
+	values := cloneValues(chrt.Values)
 	// Default endpoint for tests that don't exercise the required guard.
 	// Caller overrides via the overrides map if it wants to trigger `required`.
 	if v, _ := values["endpoint"].(string); v == "" {
@@ -1147,8 +1183,9 @@ func renderGenericWith(t *testing.T, lookup func(string, string, string) (map[st
 	if err != nil {
 		t.Fatalf("load chart: %v", err)
 	}
-	values := make(map[string]any)
-	maps.Copy(values, chrt.Values)
+	// Deep-copy chart values so mutations in this helper (or in the
+	// caller's overrides) never leak into chrt.Values.
+	values := cloneValues(chrt.Values)
 	if v, _ := values["endpoint"].(string); v == "" {
 		values["endpoint"] = testEndpoint
 	}

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -28,6 +28,13 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
+// testEndpoint is the cluster endpoint injected by tests that do not
+// specifically exercise the `required endpoint` guard. The chart's
+// shipped values.yaml leaves `endpoint` empty so a fresh install
+// surfaces the missing value loudly; tests need to supply their own
+// placeholder so they can exercise the rest of the chart.
+const testEndpoint = "https://talm-test.invalid:6443"
+
 // renderChartTemplate renders a chart template in offline mode and returns the output.
 // talosVersion sets the TalosVersion in the Helm engine context (empty string for legacy).
 func renderChartTemplate(t *testing.T, chartPath string, templateFile string, talosVersion ...string) string {
@@ -48,8 +55,18 @@ func renderChartTemplate(t *testing.T, chartPath string, templateFile string, ta
 		tv = talosVersion[0]
 	}
 
+	// Inject a test endpoint when the chart's shipped default is empty
+	// (true for cozystack and generic presets post-issue-25 fix). Tests
+	// that specifically exercise the required-endpoint guard build their
+	// own values maps and do not go through this helper.
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	if v, _ := values["endpoint"].(string); v == "" {
+		values["endpoint"] = testEndpoint
+	}
+
 	rootValues := chartutil.Values{
-		"Values":       chrt.Values,
+		"Values":       values,
 		"TalosVersion": tv,
 	}
 
@@ -317,6 +334,7 @@ func TestLegacyCozystack_NrHugepages(t *testing.T) {
 	values := make(map[string]any)
 	maps.Copy(values, chrt.Values)
 	values["nr_hugepages"] = 1024
+	values["endpoint"] = testEndpoint
 
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
@@ -346,6 +364,7 @@ func TestMultiDocCozystack_NrHugepages(t *testing.T) {
 	values := make(map[string]any)
 	maps.Copy(values, chrt.Values)
 	values["nr_hugepages"] = 1024
+	values["endpoint"] = testEndpoint
 
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
@@ -820,9 +839,13 @@ func TestMultiDocCozystack_BondTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
-		"Values":       chrt.Values,
+		"Values":       values,
 		"TalosVersion": "v1.12",
 	})
 	if err != nil {
@@ -853,9 +876,13 @@ func TestMultiDocCozystack_VlanOnBondTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
-		"Values":       chrt.Values,
+		"Values":       values,
 		"TalosVersion": "v1.12",
 	})
 	if err != nil {
@@ -883,9 +910,13 @@ func TestMultiDocGeneric_BondTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
-		"Values":       chrt.Values,
+		"Values":       values,
 		"TalosVersion": "v1.12",
 	})
 	if err != nil {
@@ -912,9 +943,13 @@ func TestMultiDocGeneric_VlanOnBondTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
-		"Values":       chrt.Values,
+		"Values":       values,
 		"TalosVersion": "v1.12",
 	})
 	if err != nil {
@@ -1068,6 +1103,11 @@ func renderCozystackWith(t *testing.T, lookup func(string, string, string) (map[
 	}
 	values := make(map[string]any)
 	maps.Copy(values, chrt.Values)
+	// Default endpoint for tests that don't exercise the required guard.
+	// Caller overrides via the overrides map if it wants to trigger `required`.
+	if v, _ := values["endpoint"].(string); v == "" {
+		values["endpoint"] = testEndpoint
+	}
 	maps.Copy(values, overrides)
 
 	eng := helmEngine.Engine{}
@@ -1094,6 +1134,9 @@ func renderGenericWith(t *testing.T, lookup func(string, string, string) (map[st
 	}
 	values := make(map[string]any)
 	maps.Copy(values, chrt.Values)
+	if v, _ := values["endpoint"].(string); v == "" {
+		values["endpoint"] = testEndpoint
+	}
 	maps.Copy(values, overrides)
 
 	eng := helmEngine.Engine{}
@@ -1216,5 +1259,71 @@ func TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery(t *testing.T) {
 	assertContains(t, result, "- 192.168.201.10/24")
 	if strings.Contains(result, "192.168.100.0/24") {
 		t.Errorf("output contains stale placeholder 192.168.100.0/24:\n%s", result)
+	}
+}
+
+// TestMultiDocCozystack_ShippedDefaultsFailFresh asserts that a fresh
+// `talm init -p cozystack` user who keeps values.yaml defaults gets a
+// loud `required` error — not a silently-embedded placeholder
+// endpoint. Unlike TestMultiDocCozystack_EndpointRequired, this test
+// does NOT override `endpoint` manually; it relies exclusively on
+// what the chart ships by default, so it catches any future regression
+// that puts a non-empty placeholder back into values.yaml.
+func TestMultiDocCozystack_ShippedDefaultsFailFresh(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = simpleNicLookup()
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+
+	eng := helmEngine.Engine{}
+	// Render with chrt.Values exactly as shipped — no test injection.
+	_, err = eng.Render(chrt, chartutil.Values{
+		"Values":       chrt.Values,
+		"TalosVersion": "v1.12",
+	})
+	if err == nil {
+		t.Fatal("expected render to fail on shipped defaults — values.yaml must not ship a placeholder endpoint that silently satisfies required()")
+	}
+	if !strings.Contains(err.Error(), "endpoint") {
+		t.Errorf("error should mention 'endpoint'; got: %v", err)
+	}
+}
+
+// TestMultiDocCozystack_WorkerValidSubnetsFallsBackToDiscovery pins
+// the fallback on worker nodes. The kubelet.validSubnets block lives
+// in the shared talos.config.machine.common definition, so it is
+// emitted for both controlplane and worker templates — this test
+// catches a regression that would only break the worker path.
+func TestMultiDocCozystack_WorkerValidSubnetsFallsBackToDiscovery(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = simpleNicLookup()
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+	values["advertisedSubnets"] = []any{}
+
+	eng := helmEngine.Engine{}
+	out, err := eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	result := out["cozystack/templates/worker.yaml"]
+	assertContains(t, result, "validSubnets:")
+	assertContains(t, result, "- 192.168.201.10/24")
+	if strings.Contains(result, "192.168.100.0/24") {
+		t.Errorf("worker output contains stale placeholder 192.168.100.0/24:\n%s", result)
 	}
 }

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -35,6 +35,13 @@ import (
 // placeholder so they can exercise the rest of the chart.
 const testEndpoint = "https://talm-test.invalid:6443"
 
+// testAdvertisedSubnet is injected for tests that do not supply a
+// discovery fixture (so the chart's empty-discovery required() guard
+// doesn't fire in unrelated tests). Tests that specifically exercise
+// the discovery fallback or the empty-discovery guard override
+// advertisedSubnets explicitly.
+const testAdvertisedSubnet = "192.168.1.0/24"
+
 // renderChartTemplate renders a chart template in offline mode and returns the output.
 // talosVersion sets the TalosVersion in the Helm engine context (empty string for legacy).
 func renderChartTemplate(t *testing.T, chartPath string, templateFile string, talosVersion ...string) string {
@@ -55,14 +62,18 @@ func renderChartTemplate(t *testing.T, chartPath string, templateFile string, ta
 		tv = talosVersion[0]
 	}
 
-	// Inject a test endpoint when the chart's shipped default is empty
-	// (true for cozystack and generic presets post-issue-25 fix). Tests
-	// that specifically exercise the required-endpoint guard build their
-	// own values maps and do not go through this helper.
+	// Inject test defaults when the chart ships empty values (true
+	// for cozystack and generic presets post-issue-25 fix). Tests
+	// that specifically exercise the required-endpoint or empty-
+	// discovery guards build their own values maps and do not go
+	// through this helper.
 	values := make(map[string]any)
 	maps.Copy(values, chrt.Values)
 	if v, _ := values["endpoint"].(string); v == "" {
 		values["endpoint"] = testEndpoint
+	}
+	if arr, ok := values["advertisedSubnets"].([]any); !ok || len(arr) == 0 {
+		values["advertisedSubnets"] = []any{testAdvertisedSubnet}
 	}
 
 	rootValues := chartutil.Values{
@@ -335,6 +346,7 @@ func TestLegacyCozystack_NrHugepages(t *testing.T) {
 	maps.Copy(values, chrt.Values)
 	values["nr_hugepages"] = 1024
 	values["endpoint"] = testEndpoint
+	values["advertisedSubnets"] = []any{testAdvertisedSubnet}
 
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
@@ -365,6 +377,7 @@ func TestMultiDocCozystack_NrHugepages(t *testing.T) {
 	maps.Copy(values, chrt.Values)
 	values["nr_hugepages"] = 1024
 	values["endpoint"] = testEndpoint
+	values["advertisedSubnets"] = []any{testAdvertisedSubnet}
 
 	eng := helmEngine.Engine{}
 	out, err := eng.Render(chrt, chartutil.Values{
@@ -1165,7 +1178,7 @@ func TestMultiDocCozystack_ValidSubnetsFallsBackToDiscovery(t *testing.T) {
 	// The discovered CIDR must appear under kubelet.validSubnets and
 	// must NOT contain the historical 192.168.100.0/24 placeholder.
 	assertContains(t, result, "validSubnets:")
-	assertContains(t, result, "- 192.168.201.10/24")
+	assertContains(t, result, "- 192.168.201.0/24")
 	if strings.Contains(result, "192.168.100.0/24") {
 		t.Errorf("output contains stale placeholder 192.168.100.0/24:\n%s", result)
 	}
@@ -1181,7 +1194,7 @@ func TestMultiDocCozystack_AdvertisedSubnetsFallsBackToDiscovery(t *testing.T) {
 	// etcd.advertisedSubnets section must appear (controlplane only)
 	// and list the discovered CIDR.
 	assertContains(t, result, "advertisedSubnets:")
-	assertContains(t, result, "- 192.168.201.10/24")
+	assertContains(t, result, "- 192.168.201.0/24")
 }
 
 // TestMultiDocCozystack_ValuesAdvertisedSubnetsOverridesDiscovery
@@ -1208,11 +1221,13 @@ func TestMultiDocCozystack_ValuesAdvertisedSubnetsOverridesDiscovery(t *testing.
 		t.Errorf("operator override 10.0.0.0/8 should appear in both validSubnets and advertisedSubnets; saw %d occurrence(s):\n%s", got, result)
 	}
 	// Ensure the discovered CIDR did NOT leak into the subnet-selector
-	// fields. We rely on YAML list-item indentation to disambiguate
-	// from LinkConfig's `- address: ...` line, which is structurally
-	// different.
-	if strings.Contains(result, "- 192.168.201.10/24\n") {
-		t.Errorf("operator override should win but discovered CIDR leaked into a subnet-selector list:\n%s", result)
+	// fields. The fallback emits the canonical network form
+	// (192.168.201.0/24) via cidrNetwork, while LinkConfig emits the
+	// host-form as `- address: 192.168.201.10/24` — so checking for
+	// the bare canonical form in the output is a strong signal that
+	// the fallback fired despite the operator override.
+	if strings.Contains(result, "- 192.168.201.0/24\n") {
+		t.Errorf("operator override should win but fallback-form subnet leaked into a subnet-selector list:\n%s", result)
 	}
 }
 
@@ -1256,7 +1271,7 @@ func TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery(t *testing.T) {
 	})
 
 	assertContains(t, result, "validSubnets:")
-	assertContains(t, result, "- 192.168.201.10/24")
+	assertContains(t, result, "- 192.168.201.0/24")
 	if strings.Contains(result, "192.168.100.0/24") {
 		t.Errorf("output contains stale placeholder 192.168.100.0/24:\n%s", result)
 	}
@@ -1293,6 +1308,41 @@ func TestMultiDocCozystack_ShippedDefaultsFailFresh(t *testing.T) {
 	}
 }
 
+// TestMultiDocCozystack_EmptyDiscoveryErrors pins that when the
+// operator leaves advertisedSubnets empty AND discovery returns
+// nothing (no default-gateway-bearing link found), the chart fails
+// loudly via required() instead of silently emitting an empty
+// validSubnets list. A silent empty list would be worse than the
+// previous buggy default because nothing surfaces the problem.
+func TestMultiDocCozystack_EmptyDiscoveryErrors(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = func(string, string, string) (map[string]any, error) {
+		return map[string]any{}, nil
+	}
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = testEndpoint
+	values["advertisedSubnets"] = []any{}
+
+	eng := helmEngine.Engine{}
+	_, err = eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err == nil {
+		t.Fatal("expected required() error when advertisedSubnets is empty and discovery yields nothing")
+	}
+	if !strings.Contains(err.Error(), "advertisedSubnets") {
+		t.Errorf("error should mention advertisedSubnets / default route; got: %v", err)
+	}
+}
+
 // TestMultiDocCozystack_WorkerValidSubnetsFallsBackToDiscovery pins
 // the fallback on worker nodes. The kubelet.validSubnets block lives
 // in the shared talos.config.machine.common definition, so it is
@@ -1322,7 +1372,7 @@ func TestMultiDocCozystack_WorkerValidSubnetsFallsBackToDiscovery(t *testing.T) 
 	}
 	result := out["cozystack/templates/worker.yaml"]
 	assertContains(t, result, "validSubnets:")
-	assertContains(t, result, "- 192.168.201.10/24")
+	assertContains(t, result, "- 192.168.201.0/24")
 	if strings.Contains(result, "192.168.100.0/24") {
 		t.Errorf("worker output contains stale placeholder 192.168.100.0/24:\n%s", result)
 	}

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -964,3 +964,257 @@ func TestRenderInvalidTalosVersion(t *testing.T) {
 		})
 	}
 }
+
+// simpleNicLookup returns a lookup fixture exposing one physical
+// interface (eth0) with address 192.168.201.10/24 and default route
+// via 192.168.201.1. Used by the discovery-fallback tests below — the
+// specific subnet is intentionally different from the 192.168.100.*
+// placeholders baked into charts' historical defaults so the tests
+// can distinguish "discovered" from "default" output.
+func simpleNicLookup() func(string, string, string) (map[string]any, error) {
+	eth0 := map[string]any{
+		"metadata": map[string]any{"id": "eth0"},
+		"spec": map[string]any{
+			"kind":         "physical",
+			"index":        1,
+			"hardwareAddr": "aa:bb:cc:00:00:01",
+			"busPath":      "pci-0000:00:1f.0",
+		},
+	}
+	routesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{
+				"spec": map[string]any{
+					"dst":         "",
+					"gateway":     "192.168.201.1",
+					"outLinkName": "eth0",
+					"family":      "inet4",
+					"table":       "main",
+				},
+			},
+		},
+	}
+	linksList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      []any{eth0},
+	}
+	addressesList := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items": []any{
+			map[string]any{
+				"spec": map[string]any{
+					"linkName": "eth0",
+					"address":  "192.168.201.10/24",
+					"family":   "inet4",
+					"scope":    "global",
+				},
+			},
+		},
+	}
+	nodeDefault := map[string]any{
+		"spec": map[string]any{
+			"addresses": []any{"192.168.201.10/24"},
+		},
+	}
+	resolvers := map[string]any{
+		"spec": map[string]any{
+			"dnsServers": []any{"8.8.8.8"},
+		},
+	}
+	return func(resource, namespace, id string) (map[string]any, error) {
+		switch resource {
+		case "routes":
+			return routesList, nil
+		case "links":
+			if id == "eth0" {
+				return eth0, nil
+			}
+			if id == "" {
+				return linksList, nil
+			}
+			return map[string]any{}, nil
+		case "addresses":
+			return addressesList, nil
+		case "nodeaddress":
+			if id == "default" {
+				return nodeDefault, nil
+			}
+		case "resolvers":
+			if id == "resolvers" {
+				return resolvers, nil
+			}
+		}
+		return map[string]any{}, nil
+	}
+}
+
+// renderCozystackWith renders the cozystack controlplane template
+// against the supplied LookupFunc and values overrides, returning the
+// final template output or failing the test. Mirrors the pattern used
+// by the existing TestMultiDoc* suites.
+func renderCozystackWith(t *testing.T, lookup func(string, string, string) (map[string]any, error), overrides map[string]any) string {
+	t.Helper()
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = lookup
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	maps.Copy(values, overrides)
+
+	eng := helmEngine.Engine{}
+	out, err := eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return out["cozystack/templates/controlplane.yaml"]
+}
+
+// renderGenericWith is the generic-preset counterpart of renderCozystackWith.
+func renderGenericWith(t *testing.T, lookup func(string, string, string) (map[string]any, error), overrides map[string]any) string {
+	t.Helper()
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = lookup
+
+	chrt, err := loader.LoadDir("../../charts/generic")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	maps.Copy(values, overrides)
+
+	eng := helmEngine.Engine{}
+	out, err := eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return out["generic/templates/controlplane.yaml"]
+}
+
+// TestMultiDocCozystack_ValidSubnetsFallsBackToDiscovery pins the
+// issue-report fix: when values.yaml leaves advertisedSubnets empty,
+// the chart must fall back to the CIDR of the node's default-gateway-
+// bearing link rather than emitting the 192.168.100.0/24 placeholder
+// that used to be the default. Without the fallback branch, users on
+// networks other than 192.168.100.0/24 silently shipped a broken
+// kubelet.validSubnets value.
+func TestMultiDocCozystack_ValidSubnetsFallsBackToDiscovery(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{
+		"advertisedSubnets": []any{},
+	})
+
+	// The discovered CIDR must appear under kubelet.validSubnets and
+	// must NOT contain the historical 192.168.100.0/24 placeholder.
+	assertContains(t, result, "validSubnets:")
+	assertContains(t, result, "- 192.168.201.10/24")
+	if strings.Contains(result, "192.168.100.0/24") {
+		t.Errorf("output contains stale placeholder 192.168.100.0/24:\n%s", result)
+	}
+}
+
+// TestMultiDocCozystack_AdvertisedSubnetsFallsBackToDiscovery pins
+// the same fallback behavior on etcd.advertisedSubnets.
+func TestMultiDocCozystack_AdvertisedSubnetsFallsBackToDiscovery(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{
+		"advertisedSubnets": []any{},
+	})
+
+	// etcd.advertisedSubnets section must appear (controlplane only)
+	// and list the discovered CIDR.
+	assertContains(t, result, "advertisedSubnets:")
+	assertContains(t, result, "- 192.168.201.10/24")
+}
+
+// TestMultiDocCozystack_ValuesAdvertisedSubnetsOverridesDiscovery
+// pins the precedence: when an operator sets advertisedSubnets
+// explicitly in values.yaml, that value wins over the discovered CIDR
+// in both kubelet.validSubnets and etcd.advertisedSubnets (two
+// consumers of the same chart value).
+//
+// The discovered CIDR (192.168.201.10/24) is still expected to appear
+// elsewhere in the rendered output — specifically in LinkConfig under
+// the physical interface's `addresses:` list — that is the normal
+// network discovery path and not the subject of this test. What this
+// test pins is that the override does NOT leave the discovered CIDR
+// in the two subnet-selector fields.
+func TestMultiDocCozystack_ValuesAdvertisedSubnetsOverridesDiscovery(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{
+		"advertisedSubnets": []any{"10.0.0.0/8"},
+	})
+
+	// Expect 10.0.0.0/8 to appear at least twice — once in
+	// machine.kubelet.nodeIP.validSubnets and once in
+	// cluster.etcd.advertisedSubnets.
+	if got := strings.Count(result, "- 10.0.0.0/8"); got < 2 {
+		t.Errorf("operator override 10.0.0.0/8 should appear in both validSubnets and advertisedSubnets; saw %d occurrence(s):\n%s", got, result)
+	}
+	// Ensure the discovered CIDR did NOT leak into the subnet-selector
+	// fields. We rely on YAML list-item indentation to disambiguate
+	// from LinkConfig's `- address: ...` line, which is structurally
+	// different.
+	if strings.Contains(result, "- 192.168.201.10/24\n") {
+		t.Errorf("operator override should win but discovered CIDR leaked into a subnet-selector list:\n%s", result)
+	}
+}
+
+// TestMultiDocCozystack_EndpointRequired asserts that an unset or
+// empty .Values.endpoint now produces a clear error at render time
+// via Helm's required(), instead of silently embedding the stale
+// placeholder that values.yaml ships with.
+func TestMultiDocCozystack_EndpointRequired(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = simpleNicLookup()
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["endpoint"] = ""
+
+	eng := helmEngine.Engine{}
+	_, err = eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err == nil {
+		t.Fatal("expected render to fail with required() error when endpoint is empty")
+	}
+	if !strings.Contains(err.Error(), "endpoint") {
+		t.Errorf("error should mention 'endpoint'; got: %v", err)
+	}
+}
+
+// TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery mirrors the
+// cozystack-side smoke test for the generic preset. A single
+// representative assertion proves the edits apply symmetrically to
+// the generic copy of the shared machine/cluster block.
+func TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery(t *testing.T) {
+	result := renderGenericWith(t, simpleNicLookup(), map[string]any{
+		"advertisedSubnets": []any{},
+	})
+
+	assertContains(t, result, "validSubnets:")
+	assertContains(t, result, "- 192.168.201.10/24")
+	if strings.Contains(result, "192.168.100.0/24") {
+		t.Errorf("output contains stale placeholder 192.168.100.0/24:\n%s", result)
+	}
+}


### PR DESCRIPTION
## Summary

Close the loop on the `192.168.100.*` placeholder problem: `talm template` on a node in any subnet other than 192.168.100.0/24 silently produced machine configs pointing at network IPs no node actually owns.

Closes #25

## What changes

### 1. Subnet fields derive from discovery

`machine.kubelet.nodeIP.validSubnets` and `cluster.etcd.advertisedSubnets` now fall back to the CIDR of the node's default-gateway-bearing link when `values.yaml` leaves `advertisedSubnets` empty. The chart pipes the discovered address (`192.168.201.10/24`) through a new `cidrNetwork` template function — `net/netip`'s `ParsePrefix().Masked()` in 6 lines — so the emitted YAML is the canonical network form (`192.168.201.0/24`) rather than the host form. Multiple addresses on the same link are deduped via sprig's `uniq`.

Override precedence is preserved: if the operator sets `advertisedSubnets` explicitly in `values.yaml`, that wins.

When both paths fail (operator didn't set it, discovery returned nothing), the chart fails loudly with a `required()` error that explains both remediations (set it explicitly, or fix the node's default route) — not silently emit an empty list.

### 2. Cluster-wide fields are now `required` instead of placeholder-defaulted

Three fields shipped with `192.168.100.*` placeholder defaults that silently produced broken configs for anyone not on that subnet:

- `endpoint` — what every node's kubelet and kube-proxy dials.
- `floatingIP` (cozystack preset) — drives the Layer-2 VIP document.
- Implicitly the coupling between them: they must match for a VIP setup.

All three are now blank by default. `endpoint` triggers a `required()` guard with a verbose message that explains *why* auto-derivation isn't possible (`talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint) and enumerates the viable options (cozystack VIP, external LB, single-node routable IP). `floatingIP` emits no `Layer2VIPConfig` document when blank, which is the correct behavior for single-node and external-LB topologies.

### 3. Documentation matches reality

- `charts/cozystack/values.yaml` and `charts/generic/values.yaml` — rewritten comments explain the decision tree (cozystack VIP vs single-node vs external LB) and the `endpoint`/`floatingIP` coupling.
- `README.md` "Getting Started" — adds the required `values.yaml` edit step between `talm init` and `talm template`. Example values match the tutorial's node IP so a reader walking the example doesn't see placeholder-vs-tutorial drift.

### 4. Test coverage

`pkg/engine/render_test.go` gains tests for:

- `validSubnets` and `advertisedSubnets` discovery fallback (controlplane + worker + generic preset).
- Override precedence: operator `values.yaml` wins.
- Empty-discovery `required()` guard fires with both the field name and the remediation phrase in the error.
- Shipped-defaults regression guard: fresh `chrt.Values` render fails, catching any future commit that re-introduces a placeholder.
- VIP-when-set: Layer2VIPConfig emitted only when operator sets `floatingIP`.
- No-VIP on fresh defaults.
- Dedupe: two addresses in the same subnet on one link collapse to one entry per consumer.

`pkg/engine/helm/engine_test.go` gains `TestCidrNetworkTemplateFunc` — direct IPv4/IPv6 unit test of the new template function (7 cases including already-canonical, narrow prefix, malformed inputs).

## Migration notes for existing users

- Anyone who `talm init`'d before and left `values.yaml` defaults now sees a `required` error on next `talm template`. Remediation is in the error message.
- Anyone who explicitly set `endpoint` and `advertisedSubnets` in `values.yaml` is unaffected.
- Anyone who relied on the cozystack `floatingIP: 192.168.100.10` default (unlikely, given it was network-incorrect for most users) now needs to set it explicitly.

## Verification

- `go test ./...` on macOS — pass
- `GOOS=windows GOARCH=amd64 go build ./...` — clean
- `golangci-lint run ./...` — 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced README with detailed configuration guidance for control-plane endpoint and VIP setup across deployment scenarios.

* **Configuration Changes**
  * Removed default values for control-plane endpoint, floating IP, and subnet configuration; explicit values now required.

* **Improvements**
  * Added automatic subnet discovery from network interfaces when not explicitly configured.
  * Strengthened validation with clearer error messages for required settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->