### PR TITLE
chore(deps): bump github.com/moby/spdystream to v0.5.1 (CVE-2026-35469)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/moby/api v1.54.1 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/moby/api v1.54.1 h1:TqVzuJkOLsgLDDwNLmYqACUuTehOHRGKiPhvH8V3Nn4=
 github.com/moby/moby/api v1.54.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
Bumps the transitive dependency `github.com/moby/spdystream` from v0.5.0 to v0.5.1 to patch [CVE-2026-35469](https://github.com/moby/spdystream/security/advisories/GHSA-pc3f-x583-g7j2) (HIGH).

## What

The SPDY/3 frame parser in spdystream <= v0.5.0 allocates memory based on attacker-controlled counts and lengths from SETTINGS and header frames. A remote peer that can send SPDY frames to a service can crash the process with a single crafted control frame (memory amplification → OOM). v0.5.1 adds bounds checks on `numSettings`, header counts, and per-field sizes, plus configurable limits via new functional options.

## Why this is a clean bump

- Pulled in transitively via `talm → siderolabs/talos → hydrophone → k8s.io/client-go → k8s.io/apimachinery → moby/spdystream` (`go mod why`).
- v0.5.1 is a pure patch release: only the security fixes plus opt-in functional options (`NewConnectionWithOptions`, `WithMaxControlFramePayloadSize`, `WithMaxHeaderFieldSize`, `WithMaxHeaderCount`). No breaking API changes.
- MVS picks v0.5.1 without needing a `replace`; no parent dep requires a different version.
- Diff is two lines in `go.mod` + the matching `go.sum` hashes.

## Verification

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — all packages pass

Closes [Dependabot alert #45](https://github.com/cozystack/talm/security/dependabot/45).