### PR TITLE
fix(engine): idempotent talm apply for object-array and merge:replace fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,27 @@ talm template -f nodes/node1.yaml -I
 > only files (no body) are still allowed and drive the same rendered
 > template on every listed target.
 >
+> **Idempotent applies.** Repeated `talm apply` runs against an
+> already-configured node do not duplicate entries. Before the strategic
+> merge runs, the engine prunes from the body every primitive-list
+> entry the rendered template already carries (e.g. certSANs,
+> nameservers, validSubnets). For object arrays the upstream patcher
+> merges by identity (machine.network.interfaces by `interface:` or
+> `deviceSelector:`, vlans by `vlanId:`, apiServer admissionControl by
+> `name:`), the prune descends into matched pairs and dedupes the inner
+> primitive lists too — so re-applying after `talm template -I` does not
+> double interface addresses, vlan addresses, or admission-control
+> exemption namespaces. For object arrays without an upstream identity
+> merge (extraVolumes, kernel.modules, wireguard.peers, ...), body items
+> that deep-equal a rendered counterpart are dropped, covering the
+> dominant full-restate case. Fields tagged `merge:"replace"` upstream
+> are passed through verbatim — pruning them would let the upstream
+> replace silently drop the rendered entries on a partial edit. This
+> covers v1alpha1 root paths `cluster.network.podSubnets`,
+> `cluster.network.serviceSubnets`, `cluster.apiServer.auditPolicy`,
+> and the typed `NetworkRuleConfig` paths `ingress` and
+> `portSelector.ports`.
+>
 > `talm template -f node.yaml` (with or without `-I`) does **not** apply
 > the same overlay: its output is the rendered template plus the modeline
 > and the auto-generated warning, byte-identical to what the template

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -604,6 +604,51 @@ func pruneBodyIdentitiesAgainstRendered(body, rendered []byte) ([]byte, bool, er
 	return buf.Bytes(), false, nil
 }
 
+// replaceSemanticPaths lists YAML paths where Talos's upstream merge
+// layer is annotated with `merge:"replace"`: at those paths, the
+// patcher overwrites rendered's value with body's verbatim — unless
+// body is the zero value, in which case rendered survives. Each entry
+// mirrors a struct field tagged `merge:"replace"` in the upstream
+// machinery types (collected from
+// pkg/machinery/config/types/v1alpha1/v1alpha1_types.go and
+// pkg/machinery/config/types/network/rule_config.go):
+//
+//   - cluster/network/podSubnets — v1alpha1 `PodSubnet []string ... merge:"replace"`
+//   - cluster/network/serviceSubnets — v1alpha1 `ServiceSubnet []string ... merge:"replace"`
+//   - cluster/apiServer/auditPolicy — v1alpha1 `AuditPolicyConfig Unstructured ... merge:"replace"`
+//   - ingress — typed NetworkRuleConfig `Ingress IngressConfig ... merge:"replace"`
+//   - portSelector/ports — typed NetworkRuleConfig `Ports PortRanges ... merge:"replace"`
+//
+// At these paths the prune must NOT subtract rendered-side entries from
+// body's primitive list, recurse into body's map, or descend into body's
+// object array: any of those reduce body to "just the user's deltas",
+// the upstream replace then writes those deltas verbatim, and rendered's
+// other entries / map keys silently vanish from the merged config — a
+// partial-edit on podSubnets that adds a CIDR ends up losing the
+// original; a partial-edit on auditPolicy that adds a rule loses the
+// rendered apiVersion/kind/other rules.
+//
+// Paths are walked relative to the document root that owns the field,
+// so the typed NetworkRuleConfig entries appear without an apiVersion/
+// kind prefix — pruneBodyIdentitiesAgainstRendered pairs body and
+// rendered docs by identity tuple before calling pruneIdenticalKeys, so
+// each walk sees only its own document's keys. The bare paths above do
+// not collide with anything in the v1alpha1 root (no `ingress` or
+// `portSelector` keys exist there), so a flat lookup is sufficient.
+//
+// The deep-equal short-circuit at the top of pruneIdenticalKeysAt is
+// still safe for replace paths: when body byte-equals rendered, deleting
+// the body key reduces body to the zero value at that path, and the
+// upstream replace then leaves rendered untouched. Skipping kicks in
+// only on the partial-edit branches below the deep-equal check.
+var replaceSemanticPaths = map[string]struct{}{
+	"cluster/network/podSubnets":     {},
+	"cluster/network/serviceSubnets": {},
+	"cluster/apiServer/auditPolicy":  {},
+	"ingress":                        {},
+	"portSelector/ports":             {},
+}
+
 // objectArrayMergeKeys lists the identity fields Talos's upstream
 // strategic-merge layer uses to match elements of an object array at
 // the given YAML path. Each entry mirrors a custom Merge method on the
@@ -643,6 +688,16 @@ func pruneBodyIdentitiesAgainstRendered(body, rendered []byte) ([]byte, bool, er
 // after `talm template -I` writes the rendered template back as the body),
 // preserving idempotence on full restates without inventing identity
 // where the upstream layer recognises none.
+//
+// One upstream type with a custom Merge is intentionally omitted:
+// ConfigFileList (typed ExtensionServiceConfig.configFiles, matched by
+// mountPath). Its element ConfigFile carries only string fields, so the
+// upstream mergeConfigFile + merge.Merge field-by-field already produces
+// the right result on partial edits — the deep-equal fallback in
+// matchObjectArrayItem handles full-restate idempotence, and adding a
+// path-keyed identity match would not change correctness, only firing
+// path. Listing it would be misleading: the table is meant to call out
+// fields where the inner-primitive append regression is reachable.
 //
 // Routes (machine.network.interfaces[].routes) sit in this same fallback
 // bucket: the schema declares no single primary key for a route, so the
@@ -702,6 +757,12 @@ func pruneIdenticalKeysAt(body, rendered map[string]any, yamlPath string) {
 			continue
 		}
 		childPath := joinYAMLPath(yamlPath, k)
+		if _, replace := replaceSemanticPaths[childPath]; replace {
+			// Upstream `merge:"replace"` overwrites rendered with body
+			// verbatim. Any prune at this path leaks rendered-side
+			// entries out of the final config — see replaceSemanticPaths.
+			continue
+		}
 		if bodySub, ok := bodyV.(map[string]any); ok {
 			if renderedSub, ok2 := renderedV.(map[string]any); ok2 {
 				// Only delete when the recursive prune actually

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -604,6 +604,55 @@ func pruneBodyIdentitiesAgainstRendered(body, rendered []byte) ([]byte, bool, er
 	return buf.Bytes(), false, nil
 }
 
+// objectArrayMergeKeys lists the identity fields Talos's upstream
+// strategic-merge layer uses to match elements of an object array at
+// the given YAML path. Each entry mirrors a custom Merge method on the
+// corresponding v1alpha1 List type: when upstream merges-by-identity at
+// a path, this prune must too, or partial edits would re-attach
+// identity-bearing fields onto a body element that the patcher would
+// then RE-merge in place — appending the inner primitive arrays
+// (addresses, nested vlan addresses, exemption namespaces) and
+// duplicating every rendered entry on every apply round-trip.
+//
+// Paths are slash-joined relative to the document root, with no leading
+// slash and no array-index suffix — array elements share the parent's
+// path. The list per path is checked in order against BODY only: the
+// first key body sets to a non-empty value (in declaration order,
+// mirroring upstream's switch enumeration) is used as the SOLE match
+// key against rendered. matchObjectArrayItem does the body-driven
+// selection — see its doc comment for why an "any-key-both-have"
+// intersection would silently drop user-adds.
+//
+// Only the three paths below have a confirmed custom upstream Merge:
+//
+//   - machine.network.interfaces — NetworkDeviceList.Merge matches by
+//     DeviceInterface (`interface`) or DeviceSelector (`deviceSelector`).
+//   - machine.network.interfaces[].vlans — VlanList.Merge matches by
+//     VlanID (`vlanId`).
+//   - cluster.apiServer.admissionControl — AdmissionPluginConfigList.Merge
+//     matches by PluginName (`name`).
+//
+// Other object arrays in the v1alpha1 schema (extraVolumes,
+// seccompProfiles, inlineManifests, kernel.modules, wireguard.peers,
+// authorizationConfig, ...) have no custom upstream Merge — the patcher
+// simply appends body's elements to rendered's. Re-attaching an identity
+// key on those would not avoid the upstream append; it would just leave
+// behind a body element that lands as a duplicate next to rendered's.
+// For those paths the deep-equal fallback in matchObjectArrayItem still
+// drops body items that byte-equal a rendered item (the dominant case
+// after `talm template -I` writes the rendered template back as the body),
+// preserving idempotence on full restates without inventing identity
+// where the upstream layer recognises none.
+//
+// Routes (machine.network.interfaces[].routes) sit in this same fallback
+// bucket: the schema declares no single primary key for a route, so the
+// only "same item" semantic available is byte-equality across all fields.
+var objectArrayMergeKeys = map[string][]string{
+	"machine/network/interfaces":         {"interface", "deviceSelector"},
+	"machine/network/interfaces/vlans":   {"vlanId"},
+	"cluster/apiServer/admissionControl": {"name"},
+}
+
 // pruneIdenticalKeys recursively deletes every body[k] that deep-equals
 // rendered[k] (mutating `body` in place — the caller still holds the
 // reference). When a body sub-map becomes empty after pruning, the whole
@@ -616,10 +665,33 @@ func pruneBodyIdentitiesAgainstRendered(body, rendered []byte) ([]byte, bool, er
 // `talm template -I` round-trip would double every certSAN, nameserver,
 // and podSubnet entry on the next apply.
 //
-// Object arrays (arrays whose elements are maps) are intentionally left
-// alone: configpatcher's StrategicMerge handles them via patchMergeKey
-// semantics that primitive subtraction would silently corrupt.
+// For object arrays the function descends into elements matched by
+// their identity field (the per-path table above, with deep-equal as
+// fallback), recurses, drops items that fully reduce to nothing, and
+// re-attaches the identity-bearing keys on items that retained payload
+// so the upstream merge can still match the element. Without this
+// descent, configpatcher.Apply matches elements by identity field
+// upstream and then appends the rendered-side primitive arrays nested
+// inside them — duplicating every interface address, route, vlan
+// address, and admission-control exemption namespace per apply
+// round-trip.
+//
+// pruneIdenticalKeys is the document-root entry point; pruneIdenticalKeysAt
+// threads the YAML path so the object-array descent can look up the
+// identity key for the current location.
 func pruneIdenticalKeys(body, rendered map[string]any) {
+	pruneIdenticalKeysAt(body, rendered, "")
+}
+
+// pruneIdenticalKeysAt is pruneIdenticalKeys's recursive workhorse.
+// yamlPath is a slash-joined YAML path from the document root (e.g.
+// "machine/network/interfaces"), used to look up the configured
+// identity field for an object-array branch. The empty path is the
+// document root.
+//
+// The parameter is named yamlPath rather than path to avoid shadowing
+// the stdlib path package imported elsewhere in this file.
+func pruneIdenticalKeysAt(body, rendered map[string]any, yamlPath string) {
 	for k, bodyV := range body {
 		renderedV, exists := rendered[k]
 		if !exists {
@@ -629,6 +701,7 @@ func pruneIdenticalKeys(body, rendered map[string]any) {
 			delete(body, k)
 			continue
 		}
+		childPath := joinYAMLPath(yamlPath, k)
 		if bodySub, ok := bodyV.(map[string]any); ok {
 			if renderedSub, ok2 := renderedV.(map[string]any); ok2 {
 				// Only delete when the recursive prune actually
@@ -638,7 +711,7 @@ func pruneIdenticalKeys(body, rendered map[string]any) {
 				// reach the merge as-is, not get silently dropped so
 				// rendered's populated value wins.
 				before := len(bodySub)
-				pruneIdenticalKeys(bodySub, renderedSub)
+				pruneIdenticalKeysAt(bodySub, renderedSub, childPath)
 				if before > 0 && len(bodySub) == 0 {
 					delete(body, k)
 				}
@@ -646,16 +719,163 @@ func pruneIdenticalKeys(body, rendered map[string]any) {
 			}
 		}
 		if bodySlice, ok := bodyV.([]any); ok {
-			if renderedSlice, ok2 := renderedV.([]any); ok2 && isPrimitiveSlice(bodySlice) && isPrimitiveSlice(renderedSlice) {
-				diff := primitiveSliceDifference(bodySlice, renderedSlice)
-				if len(diff) == 0 {
+			if renderedSlice, ok2 := renderedV.([]any); ok2 {
+				if isPrimitiveSlice(bodySlice) && isPrimitiveSlice(renderedSlice) {
+					diff := primitiveSliceDifference(bodySlice, renderedSlice)
+					if len(diff) == 0 {
+						delete(body, k)
+					} else {
+						body[k] = diff
+					}
+					continue
+				}
+				pruned := pruneObjectArrayItems(bodySlice, renderedSlice, childPath)
+				if len(pruned) == 0 {
 					delete(body, k)
 				} else {
-					body[k] = diff
+					body[k] = pruned
 				}
 			}
 		}
 	}
+}
+
+// pruneObjectArrayItems iterates body's object-array elements, matches
+// each to a rendered element by the registered identity key (or
+// deep-equal fallback), recurses into matched pairs, and drops items
+// whose payload reduced to nothing after recursion. Re-attaches the
+// identity keys from rendered when the body item retained payload but
+// the inner deep-equal pass stripped its identity-bearing fields, so
+// the upstream strategic-merge can still match the element it belongs
+// to.
+//
+// Body items that the recursion fully consumed are dropped — leaving
+// behind an item that only carries its identity key would force
+// configpatcher.Apply into a no-op match round and (when the only
+// rendered-side payload was a primitive list) re-trigger the
+// strategic-merge append we are trying to neutralise. Items with no
+// rendered counterpart are user-adds and are kept verbatim.
+func pruneObjectArrayItems(body, rendered []any, yamlPath string) []any {
+	keys := objectArrayMergeKeys[yamlPath]
+	out := make([]any, 0, len(body))
+	for _, bElem := range body {
+		bMap, ok := bElem.(map[string]any)
+		if !ok {
+			out = append(out, bElem)
+			continue
+		}
+		rMap := matchObjectArrayItem(bMap, rendered, keys)
+		if rMap == nil {
+			out = append(out, bElem)
+			continue
+		}
+		before := len(bMap)
+		pruneIdenticalKeysAt(bMap, rMap, yamlPath)
+		if before > 0 && len(bMap) == 0 {
+			continue
+		}
+		for _, idKey := range keys {
+			if _, hasInBody := bMap[idKey]; hasInBody {
+				continue
+			}
+			if v, ok := rMap[idKey]; ok {
+				bMap[idKey] = v
+			}
+		}
+		out = append(out, bMap)
+	}
+	return out
+}
+
+// matchObjectArrayItem returns the rendered map sharing an identity
+// field value with body. keys lists the allowed identity fields for
+// the current YAML path. When keys is non-empty the helper mirrors
+// upstream's body-driven selection: it picks the first identity key
+// the body sets non-empty (in the table's declaration order, matching
+// upstream's switch/case enumeration) and then matches ONLY on that
+// key. Falling back to a different key when the chosen one does not
+// match would group items the upstream patcher considers distinct —
+// e.g. body's interface=eth0 vs rendered's interface=eth1 both with
+// the same deviceSelector: upstream's NetworkDeviceList.mergeDevice
+// picks body.DeviceInterface (non-empty) and finds no match, so it
+// appends body verbatim; if the prune fell back to deviceSelector it
+// would consume body's element and silently drop the user's eth0.
+//
+// When keys is empty (no entry in objectArrayMergeKeys for the path)
+// the helper falls back to deep-equal: that catches schema fields with
+// no single primary key — most notably machine.network.interfaces[]
+// .routes — where two items are the "same" only if every field
+// matches, which is the right semantic for dedup at this layer. A
+// no-match returns nil so the caller can treat unknown items as
+// user-adds.
+func matchObjectArrayItem(body map[string]any, rendered []any, keys []string) map[string]any {
+	if len(keys) > 0 {
+		var (
+			chosenKey string
+			chosenVal any
+		)
+		for _, k := range keys {
+			if v, ok := body[k]; ok && hasIdentityValue(v) {
+				chosenKey = k
+				chosenVal = v
+				break
+			}
+		}
+		if chosenKey == "" {
+			return nil
+		}
+		for _, rElem := range rendered {
+			rMap, ok := rElem.(map[string]any)
+			if !ok {
+				continue
+			}
+			if rv, hasR := rMap[chosenKey]; hasR && reflect.DeepEqual(rv, chosenVal) {
+				return rMap
+			}
+		}
+		return nil
+	}
+	for _, rElem := range rendered {
+		if reflect.DeepEqual(rElem, body) {
+			rMap, _ := rElem.(map[string]any)
+			return rMap
+		}
+	}
+	return nil
+}
+
+// hasIdentityValue reports whether v is a non-empty identity value —
+// the analogue of upstream's `DeviceInterface != ""` and
+// `DeviceSelector != nil` predicates against a decoded map. A zero
+// string or empty map at an identity slot signals "the user did not
+// pick this identity"; the upstream switch falls through to the next
+// case in that situation, and matchObjectArrayItem must do the same
+// or it will collapse a user-add onto the wrong rendered element.
+func hasIdentityValue(v any) bool {
+	if v == nil {
+		return false
+	}
+	switch x := v.(type) {
+	case string:
+		return x != ""
+	case map[string]any:
+		return len(x) > 0
+	case []any:
+		return len(x) > 0
+	default:
+		return true
+	}
+}
+
+// joinYAMLPath returns parent + "/" + key, dropping the separator when
+// parent is the document root (the empty string). Used by the
+// object-array descent to look up the configured identity field for
+// the current location in objectArrayMergeKeys.
+func joinYAMLPath(parent, key string) string {
+	if parent == "" {
+		return key
+	}
+	return parent + "/" + key
 }
 
 // isPrimitiveSlice reports whether every element of `s` is a YAML scalar

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -700,3 +700,201 @@ func TestPrimitiveSliceDifference_ReorderCollapsesToEmpty(t *testing.T) {
 		t.Errorf("expected empty diff for reordered-but-identical-set slices, got %v", got)
 	}
 }
+
+// TestPruneIdenticalKeysAt_RecursesIntoObjectArrayMatchedByIdentityKey
+// pins that pruneIdenticalKeysAt descends into object-array elements
+// matched by their identity key (here `interface:` for the
+// machine/network/interfaces path) and dedupes nested primitive
+// arrays inside the matched pair. Without this descent,
+// configpatcher.Apply matches the outer object-array element by
+// `interface:` upstream, recurses into it, and appends the inner
+// primitive list (`addresses`) — silently doubling every rendered
+// address on every apply round-trip when the body re-states the
+// rendered values plus a partial edit.
+func TestPruneIdenticalKeysAt_RecursesIntoObjectArrayMatchedByIdentityKey(t *testing.T) {
+	body := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "enp0s31f6",
+				"addresses": []any{"88.99.249.47/26", "10.0.0.99/24"},
+			},
+		},
+	}
+	rendered := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "enp0s31f6",
+				"addresses": []any{"88.99.249.47/26"},
+			},
+		},
+	}
+
+	pruneIdenticalKeysAt(body, rendered, "machine/network")
+
+	ifaces, ok := body["interfaces"].([]any)
+	if !ok {
+		t.Fatalf("expected body[interfaces] to remain as a slice, got %#v", body["interfaces"])
+	}
+	if len(ifaces) != 1 {
+		t.Fatalf("expected one interface item retained for the partial edit, got %d: %#v", len(ifaces), ifaces)
+	}
+	iface, ok := ifaces[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected interface item to be a map, got %#v", ifaces[0])
+	}
+	if iface["interface"] != "enp0s31f6" {
+		t.Errorf("identity key `interface` must survive the prune so the upstream merge can match the element, got %#v", iface["interface"])
+	}
+	addrs, ok := iface["addresses"].([]any)
+	if !ok {
+		t.Fatalf("expected addresses to remain as a slice (only the user-add 10.0.0.99/24 should survive), got %#v", iface["addresses"])
+	}
+	if len(addrs) != 1 || addrs[0] != "10.0.0.99/24" {
+		t.Errorf("expected addresses to be pruned to just [10.0.0.99/24], got %#v", addrs)
+	}
+}
+
+// TestPruneIdenticalKeysAt_DropsObjectArrayItemReducedToIdentity pins
+// that an object-array body item whose payload reduces to nothing
+// after recursion is dropped entirely. Leaving an item that only
+// carries its identity key would force configpatcher.Apply into a
+// no-op match round, and (when the only rendered-side payload was a
+// primitive list) re-trigger the strategic-merge append the prune is
+// the entire reason for existing.
+func TestPruneIdenticalKeysAt_DropsObjectArrayItemReducedToIdentity(t *testing.T) {
+	body := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "enp0s31f6",
+				"addresses": []any{"88.99.249.47/26"},
+				"routes": []any{
+					map[string]any{"network": "0.0.0.0/0", "gateway": "88.99.249.1"},
+				},
+			},
+			map[string]any{
+				"interface": "eth1",
+				"addresses": []any{"10.0.0.5/24"},
+			},
+		},
+	}
+	rendered := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "enp0s31f6",
+				"addresses": []any{"88.99.249.47/26"},
+				"routes": []any{
+					map[string]any{"network": "0.0.0.0/0", "gateway": "88.99.249.1"},
+				},
+			},
+		},
+	}
+
+	pruneIdenticalKeysAt(body, rendered, "machine/network")
+
+	ifaces, ok := body["interfaces"].([]any)
+	if !ok {
+		t.Fatalf("expected body[interfaces] to remain as a slice (eth1 is a user-add), got %#v", body["interfaces"])
+	}
+	if len(ifaces) != 1 {
+		t.Fatalf("expected the matched-and-emptied enp0s31f6 to be dropped, leaving only the eth1 user-add, got %d items: %#v", len(ifaces), ifaces)
+	}
+	if iface := ifaces[0].(map[string]any); iface["interface"] != "eth1" {
+		t.Errorf("expected the surviving interface item to be eth1 (the user-add), got %#v", iface["interface"])
+	}
+}
+
+// TestPruneIdenticalKeysAt_ObjectArrayDeepEqualFallback pins the
+// fallback behaviour for object arrays whose path is not in the
+// known-merge-keys table: items that deep-equal a rendered item are
+// dropped, even though the helper has no field name to match on.
+// This catches the routes case (no single primary key in the Talos
+// schema) and gracefully handles any future schema field that
+// objectArrayMergeKeys forgets to enumerate.
+func TestPruneIdenticalKeysAt_ObjectArrayDeepEqualFallback(t *testing.T) {
+	body := map[string]any{
+		"opaqueArray": []any{
+			map[string]any{"a": "1", "b": "2"},
+			map[string]any{"a": "3", "b": "4"},
+		},
+	}
+	rendered := map[string]any{
+		"opaqueArray": []any{
+			map[string]any{"a": "1", "b": "2"},
+		},
+	}
+
+	pruneIdenticalKeysAt(body, rendered, "unknown/path")
+
+	arr, ok := body["opaqueArray"].([]any)
+	if !ok {
+		t.Fatalf("expected opaqueArray to remain as a slice, got %#v", body["opaqueArray"])
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected the deep-equal duplicate to be pruned, got %d items: %#v", len(arr), arr)
+	}
+	if got, want := arr[0].(map[string]any)["a"], "3"; got != want {
+		t.Errorf("expected the surviving item to be the user-add (a=3), got a=%v", got)
+	}
+}
+
+// TestPruneIdenticalKeysAt_PreservesObjectArrayUserAdd pins the
+// regression-safety property: an object-array item present only in
+// body (no rendered counterpart by identity key) must reach the
+// merge intact. The dedup must never drop user-add entries — the
+// whole point is to neutralise the strategic-merge append for
+// repeated values, not to replace it with silent drop-on-write.
+func TestPruneIdenticalKeysAt_PreservesObjectArrayUserAdd(t *testing.T) {
+	body := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "eth1",
+				"addresses": []any{"10.0.0.5/24"},
+			},
+		},
+	}
+	rendered := map[string]any{
+		"interfaces": []any{
+			map[string]any{
+				"interface": "enp0s31f6",
+				"addresses": []any{"88.99.249.47/26"},
+			},
+		},
+	}
+
+	pruneIdenticalKeysAt(body, rendered, "machine/network")
+
+	ifaces, ok := body["interfaces"].([]any)
+	if !ok {
+		t.Fatalf("expected body[interfaces] to remain as a slice, got %#v", body["interfaces"])
+	}
+	if len(ifaces) != 1 {
+		t.Fatalf("expected the user-add interface to be preserved, got %d items: %#v", len(ifaces), ifaces)
+	}
+	iface := ifaces[0].(map[string]any)
+	if iface["interface"] != "eth1" {
+		t.Errorf("expected user-add interface eth1 to survive, got %#v", iface["interface"])
+	}
+}
+
+// TestJoinYAMLPath pins joinYAMLPath's contract: the document root
+// (empty parent) joins without a leading separator so the path lookup
+// in objectArrayMergeKeys matches the documented form ("machine/...");
+// every other join inserts exactly one slash.
+func TestJoinYAMLPath(t *testing.T) {
+	tests := []struct {
+		parent string
+		key    string
+		want   string
+	}{
+		{"", "machine", "machine"},
+		{"machine", "network", "machine/network"},
+		{"machine/network", "interfaces", "machine/network/interfaces"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.parent+"+"+tc.key, func(t *testing.T) {
+			if got := joinYAMLPath(tc.parent, tc.key); got != tc.want {
+				t.Errorf("joinYAMLPath(%q, %q) = %q, want %q", tc.parent, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -876,6 +876,129 @@ func TestPruneIdenticalKeysAt_PreservesObjectArrayUserAdd(t *testing.T) {
 	}
 }
 
+// TestHasIdentityValue pins the boundary cases of the body-driven
+// identity selector. Upstream's NetworkDeviceList.mergeDevice falls
+// through `case device.DeviceInterface != "":` to
+// `case device.DeviceSelector != nil:` when the first identity is the
+// zero value of its type. matchObjectArrayItem must reject empty/zero
+// identity fields the same way; otherwise an `interface: ""` body
+// would chosen-key on `interface`, find no match in rendered, and
+// preserve a body element that should have been matched via
+// `deviceSelector` instead.
+func TestHasIdentityValue(t *testing.T) {
+	tests := []struct {
+		name string
+		v    any
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty string", "", false},
+		{"non-empty string", "eth0", true},
+		{"empty map", map[string]any{}, false},
+		{"non-empty map", map[string]any{"hardwareAddr": "aa:bb:cc:dd:ee:ff"}, true},
+		{"empty slice", []any{}, false},
+		{"non-empty slice", []any{"a"}, true},
+		{"int zero", 0, true},
+		{"int non-zero", 4000, true},
+		{"bool false", false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasIdentityValue(tc.v); got != tc.want {
+				t.Errorf("hasIdentityValue(%v) = %v, want %v", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestObjectArrayMergeKeysMatchesUpstreamMergerSurface pins that the
+// table covers exactly the upstream List types whose custom Merge
+// method matches by identity AND whose elements would mishandle
+// inner-primitive append on partial edit. A new entry to the table
+// adds risk; a missing entry leaves the inner-primitive append
+// regression reachable. Either drift surfaces here so a maintainer
+// reconciles the table against the upstream merger surface
+// deliberately.
+//
+// Upstream surface (verified against the cozystack/talos fork pinned
+// in go.mod):
+//
+//   - NetworkDeviceList — yaml path `machine.network.interfaces`,
+//     identity `interface` or `deviceSelector` (body-driven switch).
+//   - VlanList — yaml path `machine.network.interfaces[].vlans`,
+//     identity `vlanId`.
+//   - AdmissionPluginConfigList — yaml path
+//     `cluster.apiServer.admissionControl`, identity `name`.
+//   - ConfigFileList (typed ExtensionServiceConfig.configFiles) —
+//     intentionally OMITTED: ConfigFile carries only string fields
+//     (hostPath, mountPath, content), so the upstream merge.Merge
+//     field-by-field already produces the right result and the
+//     deep-equal fallback in matchObjectArrayItem covers
+//     full-restate idempotence. Adding it would not change
+//     correctness; listing it would mislead readers about which
+//     types are at risk for inner-primitive append.
+func TestObjectArrayMergeKeysMatchesUpstreamMergerSurface(t *testing.T) {
+	expected := map[string][]string{
+		"machine/network/interfaces":         {"interface", "deviceSelector"},
+		"machine/network/interfaces/vlans":   {"vlanId"},
+		"cluster/apiServer/admissionControl": {"name"},
+	}
+	if len(objectArrayMergeKeys) != len(expected) {
+		t.Fatalf("table size drift: have %d entries, want %d (verify against upstream merger surface in pkg/machinery/config/types/v1alpha1/v1alpha1_types.go and config/types/runtime/extensions/service_config.go)\nhave: %#v\nwant: %#v",
+			len(objectArrayMergeKeys), len(expected), objectArrayMergeKeys, expected)
+	}
+	for path, wantKeys := range expected {
+		gotKeys, ok := objectArrayMergeKeys[path]
+		if !ok {
+			t.Errorf("missing entry for %q", path)
+			continue
+		}
+		if len(gotKeys) != len(wantKeys) {
+			t.Errorf("entry for %q: got %d keys, want %d (got=%v want=%v)", path, len(gotKeys), len(wantKeys), gotKeys, wantKeys)
+			continue
+		}
+		for i, want := range wantKeys {
+			if gotKeys[i] != want {
+				t.Errorf("entry for %q at index %d: got %q, want %q", path, i, gotKeys[i], want)
+			}
+		}
+	}
+}
+
+// TestReplaceSemanticPathsMatchesUpstreamReplaceTags pins that the
+// table covers exactly the upstream fields tagged `merge:"replace"`.
+// A `merge:"replace"` field reachable through the prune that is
+// missing from this table will silently drop rendered-side entries
+// on a partial edit; a stray entry will skip otherwise-valid prune
+// work. Either drift surfaces here.
+//
+// Upstream surface (verified against the cozystack/talos fork pinned
+// in go.mod):
+//
+//   - cluster/network/podSubnets — v1alpha1 PodSubnet
+//   - cluster/network/serviceSubnets — v1alpha1 ServiceSubnet
+//   - cluster/apiServer/auditPolicy — v1alpha1 AuditPolicyConfig
+//   - ingress — typed NetworkRuleConfig Ingress
+//   - portSelector/ports — typed NetworkRuleConfig Ports
+func TestReplaceSemanticPathsMatchesUpstreamReplaceTags(t *testing.T) {
+	expected := map[string]struct{}{
+		"cluster/network/podSubnets":     {},
+		"cluster/network/serviceSubnets": {},
+		"cluster/apiServer/auditPolicy":  {},
+		"ingress":                        {},
+		"portSelector/ports":             {},
+	}
+	if len(replaceSemanticPaths) != len(expected) {
+		t.Fatalf("table size drift: have %d entries, want %d (re-grep upstream for `merge:\"replace\"` and reconcile)\nhave: %#v\nwant: %#v",
+			len(replaceSemanticPaths), len(expected), replaceSemanticPaths, expected)
+	}
+	for path := range expected {
+		if _, ok := replaceSemanticPaths[path]; !ok {
+			t.Errorf("missing entry for %q", path)
+		}
+	}
+}
+
 // TestJoinYAMLPath pins joinYAMLPath's contract: the document root
 // (empty parent) joins without a leading separator so the path lookup
 // in objectArrayMergeKeys matches the documented form ("machine/...");

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -2108,6 +2108,319 @@ cluster:
 		}
 	})
 
+	t.Run("podSubnets partial edit preserves rendered entry", func(t *testing.T) {
+		// cluster.network.podSubnets is tagged `merge:"replace"`
+		// upstream — the patcher overwrites rendered's slice with
+		// body's slice verbatim (unless body is the zero value, in
+		// which case rendered survives). The primitive-subtract
+		// dedup must NOT fire on this path: if body re-states
+		// rendered's entry plus a user-add, subtracting rendered
+		// would strip rendered's entry from the body, the upstream
+		// replace then writes only the user-add, and rendered's
+		// pod CIDR would silently vanish from the merged config.
+		// Pin the post-fix contract: a partial edit on podSubnets
+		// must reach upstream unchanged so the replace produces
+		// the expected union.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  network:
+    podSubnets:
+      - 10.244.0.0/16
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  network:
+    podSubnets:
+      - 10.244.0.0/16
+      - 172.16.0.0/16
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "10.244.0.0/16") {
+			t.Errorf("rendered podSubnet 10.244.0.0/16 silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "172.16.0.0/16") {
+			t.Errorf("user-added podSubnet 172.16.0.0/16 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("serviceSubnets partial edit preserves rendered entry", func(t *testing.T) {
+		// Same `merge:"replace"` semantics as podSubnets — the
+		// primitive-subtract dedup would strip rendered's entry,
+		// the upstream replace would then leave only the user-add,
+		// and rendered's service CIDR would vanish.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  network:
+    serviceSubnets:
+      - 10.96.0.0/12
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  network:
+    serviceSubnets:
+      - 10.96.0.0/12
+      - 192.168.16.0/20
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "10.96.0.0/12") {
+			t.Errorf("rendered serviceSubnet 10.96.0.0/12 silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "192.168.16.0/20") {
+			t.Errorf("user-added serviceSubnet 192.168.16.0/20 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("NetworkRuleConfig ingress partial edit preserves rendered rule", func(t *testing.T) {
+		// NetworkRuleConfig is a typed v1.12+ document. Its `ingress`
+		// field is tagged `merge:"replace"` upstream. The prune walks
+		// the typed doc with path starting at the doc root, so the
+		// child path is the bare "ingress". Without that path in
+		// replaceSemanticPaths, the object-array branch's deep-equal
+		// fallback would drop body's restated rule, the upstream
+		// replace would write only the new rule, and rendered's rule
+		// would silently vanish from the merged firewall config.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubelet-ingress
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubelet-ingress
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+  - subnet: 192.168.0.0/16
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "10.0.0.0/8") {
+			t.Errorf("rendered ingress subnet 10.0.0.0/8 silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "192.168.0.0/16") {
+			t.Errorf("user-added ingress subnet 192.168.0.0/16 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("NetworkRuleConfig portSelector.ports partial edit preserves rendered port", func(t *testing.T) {
+		// portSelector.ports is the second `merge:"replace"`-tagged
+		// field on NetworkRuleConfig. The typed-doc walk reaches it
+		// at path "portSelector/ports". Without the entry in
+		// replaceSemanticPaths the primitive-subtract branch would
+		// strip rendered's port from body; the upstream replace would
+		// then leave only the user-add and the rendered port would
+		// disappear from the firewall rule.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: api-ingress
+portSelector:
+  ports:
+    - 9999
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: api-ingress
+portSelector:
+  ports:
+    - 9999
+    - 50000
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "9999") {
+			t.Errorf("rendered port 9999 silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "50000") {
+			t.Errorf("user-added port 50000 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("auditPolicy partial edit preserves rendered map keys", func(t *testing.T) {
+		// cluster.apiServer.auditPolicy is an Unstructured map tagged
+		// `merge:"replace"`: upstream overwrites the entire map with
+		// body's value (unless body is the zero value). The map-recursion
+		// branch of pruneIdenticalKeysAt would deep-equal-strip rendered's
+		// matching keys (apiVersion, kind, the unmodified rules), the
+		// body's map would then carry only the user's edit, and the
+		// upstream replace would land that minimal map as the final
+		// auditPolicy — the typed-doc identity keys and the unmodified
+		// rules vanish. Pin the post-fix contract: a partial edit on
+		// auditPolicy reaches upstream verbatim.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    auditPolicy:
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+        - level: Metadata
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    auditPolicy:
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+        - level: Metadata
+        - level: RequestResponse
+          users:
+            - alice
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "apiVersion: audit.k8s.io/v1") {
+			t.Errorf("auditPolicy apiVersion silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "kind: Policy") {
+			t.Errorf("auditPolicy kind silently lost on replace-tagged partial edit:\n%s", out)
+		}
+		if !strings.Contains(out, "RequestResponse") {
+			t.Errorf("user-added auditPolicy rule RequestResponse missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "alice") {
+			t.Errorf("user-added auditPolicy rule user alice missing from merged output:\n%s", out)
+		}
+	})
+
 	t.Run("interface identity selection mirrors upstream body-driven switch", func(t *testing.T) {
 		// Talos's NetworkDeviceList.mergeDevice picks the identity
 		// field from the BODY element being merged: if body sets

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -1914,6 +1914,411 @@ machine:
 		}
 	})
 
+	t.Run("network interface partial edit does not duplicate addresses or routes", func(t *testing.T) {
+		// rendered already populates machine.network.interfaces[interface=X]
+		// with addresses and routes; the user's body re-states the same
+		// interface with one extra address (a typical per-node edit).
+		// Talos's strategic merge matches interfaces by `interface:` and
+		// recurses into the matched element, but the inner primitive list
+		// (addresses) and the routes object array both append rather than
+		// replace — every apply round-trip thus duplicates the rendered
+		// entries once more, accumulating linearly with the number of
+		// applies. Without object-array recursion in pruneIdenticalKeys,
+		// the body's interfaces value reaches configpatcher.Apply with
+		// the rendered-side entries still present and triggers the append.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        addresses:
+          - 88.99.249.47/26
+        routes:
+          - network: 0.0.0.0/0
+            gateway: 88.99.249.1
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        addresses:
+          - 88.99.249.47/26
+          - 10.0.0.99/24
+        routes:
+          - network: 0.0.0.0/0
+            gateway: 88.99.249.1
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if got := strings.Count(out, "88.99.249.47/26"); got != 1 {
+			t.Errorf("rendered interface address 88.99.249.47/26 duplicated by partial-edit round-trip (count=%d):\n%s", got, out)
+		}
+		if got := strings.Count(out, "88.99.249.1"); got != 1 {
+			t.Errorf("rendered route gateway 88.99.249.1 duplicated by partial-edit round-trip (count=%d):\n%s", got, out)
+		}
+		if !strings.Contains(out, "10.0.0.99/24") {
+			t.Errorf("user-added address 10.0.0.99/24 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("nested vlan addresses do not duplicate", func(t *testing.T) {
+		// Same shape as the interface-addresses regression but one
+		// level deeper: machine.network.interfaces[interface=X]
+		// .vlans[vlanId=Y].addresses. Both the parent interface and
+		// the vlan are matched by their identity keys upstream, then
+		// the inner primitive `addresses` list appends. Pin the
+		// post-fix contract: identical inner primitives must not
+		// duplicate when the outer object arrays are matched.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        vlans:
+          - vlanId: 4000
+            addresses:
+              - 192.168.100.2/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        vlans:
+          - vlanId: 4000
+            addresses:
+              - 192.168.100.2/24
+              - 192.168.100.3/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if got := strings.Count(out, "192.168.100.2/24"); got != 1 {
+			t.Errorf("rendered vlan address 192.168.100.2/24 duplicated by partial-edit round-trip (count=%d):\n%s", got, out)
+		}
+		if !strings.Contains(out, "192.168.100.3/24") {
+			t.Errorf("user-added vlan address 192.168.100.3/24 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("admissionControl exemption namespaces do not duplicate", func(t *testing.T) {
+		// cluster.apiServer.admissionControl[name=PodSecurity]
+		// .configuration.exemptions.namespaces accumulates duplicates of
+		// `kube-system` on every apply round-trip. The admissionControl
+		// element is matched by its `name:` key upstream, then the
+		// nested primitive list under exemptions.namespaces appends.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+          kind: PodSecurityConfiguration
+          exemptions:
+            namespaces:
+              - kube-system
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        configuration:
+          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+          kind: PodSecurityConfiguration
+          exemptions:
+            namespaces:
+              - kube-system
+              - my-namespace
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if got := strings.Count(out, "kube-system"); got != 1 {
+			t.Errorf("rendered admissionControl exemption namespace kube-system duplicated by partial-edit round-trip (count=%d):\n%s", got, out)
+		}
+		if !strings.Contains(out, "my-namespace") {
+			t.Errorf("user-added exemption namespace my-namespace missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("interface identity selection mirrors upstream body-driven switch", func(t *testing.T) {
+		// Talos's NetworkDeviceList.mergeDevice picks the identity
+		// field from the BODY element being merged: if body sets
+		// `interface:` (non-empty), upstream matches rendered ONLY by
+		// `interface:`; otherwise upstream falls back to
+		// `deviceSelector:`. The prune must mirror that selection or
+		// it can silently drop a user-add.
+		//
+		// Concrete trap: body has interface=eth0 + a deviceSelector;
+		// rendered has interface=eth1 with the SAME deviceSelector.
+		// Upstream picks body.DeviceInterface (non-empty), looks for
+		// `eth0` in rendered, finds none, appends body verbatim — the
+		// user gets two interfaces. A prune that fell back to
+		// deviceSelector would match body[0] to rendered[0], recurse,
+		// drop everything, and ship a body that the upstream merge
+		// could not append meaningfully — eth0 and its addresses
+		// would never reach the node.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: eth1
+        deviceSelector:
+          hardwareAddr: 'aa:bb:cc:dd:ee:ff'
+        addresses:
+          - 10.0.0.5/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: eth0
+        deviceSelector:
+          hardwareAddr: 'aa:bb:cc:dd:ee:ff'
+        addresses:
+          - 10.0.0.5/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		// User's eth0 must survive with its addresses intact. Both
+		// items share addresses by accident; if the prune consumed
+		// body[0] via the deviceSelector fallback it would strip the
+		// addresses (deep-equal to rendered's), re-attach
+		// deviceSelector, and ship `{interface: eth0, deviceSelector}`
+		// — which the upstream merge then appends as a NEW element
+		// because eth0 != eth1. Result: a stranded eth0 with no
+		// addresses, no routes — silent data loss.
+		if !strings.Contains(out, "interface: eth0") {
+			t.Errorf("user-added interface eth0 silently lost (deviceSelector fallback consumed it):\n%s", out)
+		}
+		if got := strings.Count(out, "10.0.0.5/24"); got != 2 {
+			t.Errorf("expected 10.0.0.5/24 to appear twice (once under each interface), got %d:\n%s", got, out)
+		}
+		// rendered's eth1 must remain.
+		if !strings.Contains(out, "interface: eth1") {
+			t.Errorf("rendered interface eth1 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("object array without upstream merge dedupes by deep-equal fallback", func(t *testing.T) {
+		// Talos's v1alpha1 schema has many object arrays (extraVolumes,
+		// inlineManifests, kernel.modules, wireguard.peers, ...) where
+		// the upstream patcher has no custom Merge method matching by
+		// identity — it simply appends body's elements to rendered's.
+		// Adding such a path to objectArrayMergeKeys would re-attach an
+		// identity field on partial edits and the upstream append would
+		// then leave behind a duplicate next to rendered's element. The
+		// safer contract: leave such paths to the deep-equal fallback in
+		// matchObjectArrayItem, which still drops body items that
+		// byte-equal a rendered item — covering the dominant
+		// `talm template -I` round-trip scenario.
+		//
+		// Pin that contract here for cluster.apiServer.extraVolumes
+		// (one of the deliberately unlisted paths): a body that
+		// re-states rendered's volume verbatim and adds a new one must
+		// NOT duplicate the restated volume in the merged output.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    extraVolumes:
+      - hostPath: /var/lib/auth
+        mountPath: /etc/kubernetes/auth
+        readonly: true
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+  apiServer:
+    extraVolumes:
+      - hostPath: /var/lib/auth
+        mountPath: /etc/kubernetes/auth
+        readonly: true
+      - hostPath: /var/lib/audit
+        mountPath: /etc/kubernetes/audit
+        readonly: false
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if got := strings.Count(out, "/var/lib/auth"); got != 1 {
+			t.Errorf("rendered extraVolumes hostPath /var/lib/auth duplicated by user-add round-trip (count=%d):\n%s", got, out)
+		}
+		if !strings.Contains(out, "/var/lib/audit") {
+			t.Errorf("user-added extraVolume /var/lib/audit missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("body adding a new interface preserves rendered interfaces", func(t *testing.T) {
+		// Regression-safety probe for the user-add path: when the body
+		// adds an interface absent from rendered, the new interface
+		// must reach the merge intact. Object-array dedup must not
+		// over-prune body items that have no rendered counterpart.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        addresses:
+          - 88.99.249.47/26
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: enp0s31f6
+        addresses:
+          - 88.99.249.47/26
+      - interface: eth1
+        addresses:
+          - 10.0.0.5/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "enp0s31f6") {
+			t.Errorf("rendered interface enp0s31f6 missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "eth1") {
+			t.Errorf("user-added interface eth1 missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "10.0.0.5/24") {
+			t.Errorf("user-added address 10.0.0.5/24 missing from merged output:\n%s", out)
+		}
+		if got := strings.Count(out, "88.99.249.47/26"); got != 1 {
+			t.Errorf("rendered address 88.99.249.47/26 duplicated when body adds a new interface (count=%d):\n%s", got, out)
+		}
+	})
+
 	t.Run("JSON Patch body is forwarded to LoadPatch unchanged", func(t *testing.T) {
 		// MergeFileAsPatch's documented contract (and the existing
 		// LoadPatch error hint) advertises support for JSON Patch and

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -2421,6 +2421,210 @@ cluster:
 		}
 	})
 
+	t.Run("NetworkDefaultActionConfig.ingress is harmless under replace-skip", func(t *testing.T) {
+		// NetworkDefaultActionConfig is a separate typed v1.12+ doc
+		// kind that also has a top-level `ingress:` key — but in this
+		// type ingress is a SCALAR (accept/block), not an object slice.
+		// Both NetworkRuleConfig and NetworkDefaultActionConfig walks
+		// see path "ingress" at their respective doc roots, so the
+		// flat replaceSemanticPaths lookup hits both. Pin that this
+		// collision is harmless: the deep-equal short-circuit catches
+		// the body-equals-rendered case, and the replace-skip on a
+		// scalar simply preserves body's value verbatim — same outcome
+		// as the existing scalar-edit code path. If the upstream
+		// schema later changes ingress to a structured field on this
+		// kind, this test will surface the regression so a kind-aware
+		// scope can be added before correctness drifts.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkDefaultActionConfig
+ingress: accept
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkDefaultActionConfig
+ingress: block
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		if !strings.Contains(out, "ingress: block") {
+			t.Errorf("user's ingress=block override silently lost on the scalar collision path:\n%s", out)
+		}
+	})
+
+	t.Run("NetworkRuleConfig multi-doc pairs body and rendered by name identity", func(t *testing.T) {
+		// pruneBodyIdentitiesAgainstRendered keys typed-doc body docs
+		// against rendered docs by `apiVersion + kind + name`. Two
+		// NetworkRuleConfig docs sharing apiVersion/kind but differing
+		// `name:` are distinct documents — the prune must NOT collapse
+		// them. Body's user-add doc must reach the merge unmodified;
+		// only the body doc whose name matches a rendered doc gets
+		// paired and pruned.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: api-ingress
+portSelector:
+  ports:
+    - 9999
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: api-ingress
+portSelector:
+  ports:
+    - 9999
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/8
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubelet-ingress
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+ingress:
+  - subnet: 192.168.0.0/16
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		// Body's matching api-ingress should round-trip without
+		// duplicating; user-add kubelet-ingress reaches the merge
+		// intact.
+		if !strings.Contains(out, "api-ingress") {
+			t.Errorf("rendered NetworkRuleConfig api-ingress missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "kubelet-ingress") {
+			t.Errorf("user-added NetworkRuleConfig kubelet-ingress missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "10250") {
+			t.Errorf("user-added kubelet-ingress port 10250 missing from merged output:\n%s", out)
+		}
+		if !strings.Contains(out, "192.168.0.0/16") {
+			t.Errorf("user-added kubelet-ingress subnet 192.168.0.0/16 missing from merged output:\n%s", out)
+		}
+	})
+
+	t.Run("interface body without identity field reaches merge intact", func(t *testing.T) {
+		// Upstream NetworkDeviceList.mergeDevice falls through both
+		// switch cases when body has neither `interface:` nor
+		// `deviceSelector:` set, then appends body verbatim (the
+		// patched element will fail upstream validation; the prune
+		// layer's job is only to not consume it). The prune mirrors
+		// this: hasIdentityValue rejects empty/zero-valued identity
+		// fields, matchObjectArrayItem returns nil, the body item is
+		// preserved unchanged. Pin that contract so a future change
+		// to keys-driven matching does not silently collapse a body
+		// without identity onto the first rendered element.
+		const renderedTemplate = `version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - interface: eth0
+        addresses:
+          - 10.0.0.1/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		const userBody = `# talm: nodes=["10.0.0.1"]
+version: v1alpha1
+machine:
+  type: controlplane
+  install:
+    disk: /dev/sda
+  network:
+    interfaces:
+      - addresses:
+          - 10.0.0.5/24
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+		dir := t.TempDir()
+		nodeFile := filepath.Join(dir, "node0.yaml")
+		if err := os.WriteFile(nodeFile, []byte(userBody), 0o644); err != nil {
+			t.Fatalf("write node file: %v", err)
+		}
+
+		merged, err := MergeFileAsPatch([]byte(renderedTemplate), nodeFile)
+		if err != nil {
+			t.Fatalf("MergeFileAsPatch: %v", err)
+		}
+		out := string(merged)
+		// Body's identity-less item must reach the merge with its
+		// addresses intact (upstream will then reject it at validation,
+		// but that's not the prune's concern). The prune must not
+		// silently consume it onto rendered's eth0.
+		if !strings.Contains(out, "10.0.0.5/24") {
+			t.Errorf("body item without identity field silently consumed onto rendered's eth0:\n%s", out)
+		}
+		if !strings.Contains(out, "10.0.0.1/24") {
+			t.Errorf("rendered eth0 address 10.0.0.1/24 missing from merged output:\n%s", out)
+		}
+	})
+
 	t.Run("interface identity selection mirrors upstream body-driven switch", func(t *testing.T) {
 		// Talos's NetworkDeviceList.mergeDevice picks the identity
 		// field from the BODY element being merged: if body sets


### PR DESCRIPTION
## What changed

`talm apply` now preserves rendered entries when the user re-states or partially edits per-node config. The engine's pre-merge prune was correctly deduplicating primitive arrays at the top level, but had two gaps that landed as silent data loss across repeated applies:

- **Object-array nested primitives** were appended on every round-trip. When the upstream patcher matches an object-array element by identity (interface, vlanId, name) and recurses inside, nested primitive arrays (interface addresses, vlan addresses, admission-control exemption namespaces) appended rather than replaced — every apply doubled them.
- **`merge:"replace"` fields** were silently overwritten on partial edit. The prune subtracted rendered entries from body, reducing body to just the user's deltas; the upstream replace then wrote those deltas as the entire final value, losing rendered's other entries.

## Why

Both regressions are reachable through the standard `talm template -I` workflow that writes the rendered template back as the per-node body.

## How

- Extended the prune to descend into object-array elements matched by their identity field (mirroring upstream's body-driven switch).
- Added a path-based skip for `merge:"replace"` fields so body reaches the patcher verbatim.
- Table-drift tests lock both lookups against the upstream surface.

## Tests

Eleven new integration tests + unit tests for the identity selector and table contracts. README documents the round-trip dedup contract.

Closes #138.
Closes #77.
Closes #28.