### PR TITLE
feat(charts): allow overriding of the cluster's name

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -103,7 +103,7 @@ cluster:
       {{- toYaml .Values.podSubnets | nindent 6 }}
     serviceSubnets:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
-  clusterName: "{{ .Chart.Name }}"
+  clusterName: {{ .Values.clusterName | default .Chart.Name | regexFind "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | required "clusterName must be a valid DNS-1123 label" | quote }}
   controlPlane:
     endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP (cozystack floatingIP) or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -19,6 +19,12 @@
 # Example: endpoint: "https://192.168.0.1:6443"
 endpoint: ""
 
+# Optional override for the cluster's name (defaults to Chart.Name).
+# Note that changing this value on a live cluster is considered
+# dangerous as it is baked into PKI (cert SANs) and ETCD identity at
+# bootstrap.
+clusterName: ""
+
 clusterDomain: cozy.local
 # Layer-2 VIP for cozystack multi-node setups. When set, the chart
 # emits a Layer2VIPConfig document pinning this IP as a floating

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -45,13 +45,14 @@ machine:
 
 {{- /* Shared cluster section */ -}}
 {{- define "talos.config.cluster" }}
+
 cluster:
   network:
     podSubnets:
       {{- toYaml .Values.podSubnets | nindent 6 }}
     serviceSubnets:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
-  clusterName: "{{ .Chart.Name }}"
+  clusterName: {{ .Values.clusterName | default .Chart.Name | regexFind "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | required "clusterName must be a valid DNS-1123 label" | quote }}
   controlPlane:
     endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -38,6 +38,12 @@ floatingIP: ""
 # Example: vipLink: eth0.4000
 vipLink: ""
 
+# Optional override for the cluster's name (defaults to Chart.Name).
+# Note that changing this value on a live cluster is considered
+# dangerous as it is baked into PKI (cert SANs) and ETCD identity at
+# bootstrap.
+clusterName: ""
+
 podSubnets:
 - 10.244.0.0/16
 serviceSubnets:

--- a/pkg/commands/talosconfig.go
+++ b/pkg/commands/talosconfig.go
@@ -43,7 +43,7 @@ This command:
 4. Re-encrypts if encryption is used
 
 Use this command when your client certificate has expired.`,
-	Args:  cobra.NoArgs,
+	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Ensure project root is detected
 		if !Config.RootDirExplicit {
@@ -190,8 +190,19 @@ func regenerateTalosconfig() error {
 	return nil
 }
 
-// getClusterNameFromChart reads the cluster name from Chart.yaml
+// getClusterNameFromChart reads the cluster name from values.yaml or Chart.yaml
 func getClusterNameFromChart() string {
+	valuesYamlPath := filepath.Join(Config.RootDir, "values.yaml")
+	if data, err := os.ReadFile(valuesYamlPath); err == nil {
+		var valuesData struct {
+			ClusterName string `yaml:"clusterName"`
+		}
+
+		if err = yaml.Unmarshal(data, &valuesData); err == nil && valuesData.ClusterName != "" {
+			return valuesData.ClusterName
+		}
+	}
+
 	chartYamlPath := filepath.Join(Config.RootDir, "Chart.yaml")
 	data, err := os.ReadFile(chartYamlPath)
 	if err != nil {
@@ -208,4 +219,3 @@ func getClusterNameFromChart() string {
 
 	return chartData.Name
 }
-

--- a/pkg/engine/render_test.go
+++ b/pkg/engine/render_test.go
@@ -228,7 +228,7 @@ func TestLegacyCozystack_ControlPlane(t *testing.T) {
 
 	// Legacy format: cluster section present
 	assertContains(t, output, "cluster:")
-	assertContains(t, output, "clusterName:")
+	assertContains(t, output, "clusterName: \"cozystack\"")
 	assertContains(t, output, "controlPlane:")
 	assertContains(t, output, "endpoint:")
 
@@ -289,7 +289,7 @@ func TestLegacyGeneric_ControlPlane(t *testing.T) {
 
 	// Legacy format: cluster section present
 	assertContains(t, output, "cluster:")
-	assertContains(t, output, "clusterName:")
+	assertContains(t, output, "clusterName: \"generic\"")
 	assertContains(t, output, "controlPlane:")
 	assertContains(t, output, "endpoint:")
 
@@ -342,7 +342,7 @@ func TestMultiDocCozystack_ControlPlane(t *testing.T) {
 
 	// Multi-doc: cluster section unchanged
 	assertContains(t, output, "cluster:")
-	assertContains(t, output, "clusterName:")
+	assertContains(t, output, "clusterName: \"cozystack\"")
 	assertContains(t, output, "controlPlane:")
 	assertContains(t, output, "allowSchedulingOnControlPlanes:")
 	assertContains(t, output, "etcd:")
@@ -504,7 +504,7 @@ func TestMultiDocGeneric_ControlPlane(t *testing.T) {
 
 	// Multi-doc: cluster section still present
 	assertContains(t, output, "cluster:")
-	assertContains(t, output, "clusterName:")
+	assertContains(t, output, "clusterName: \"generic\"")
 	assertContains(t, output, "controlPlane:")
 	assertContains(t, output, "endpoint:")
 
@@ -4105,6 +4105,84 @@ func TestMultiDocCozystack_EndpointRequired(t *testing.T) {
 	if !strings.Contains(err.Error(), "endpoint") {
 		t.Errorf("error should mention 'endpoint'; got: %v", err)
 	}
+}
+
+// TestMultiDocCozystack_InvalidClusterNameOverride ensures invalid
+// clusterName overrides are rejected
+func TestMultiDocCozystack_InvalidClusterNameOverride(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = simpleNicLookup()
+
+	chrt, err := loader.LoadDir("../../charts/cozystack")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["clusterName"] = "InvalidClusterName"
+
+	eng := helmEngine.Engine{}
+	_, err = eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err == nil {
+		t.Fatal("expected render to fail with required() error when clusterName is invalid")
+	}
+	if !strings.Contains(err.Error(), "clusterName") {
+		t.Errorf("error should mention 'clusterName'; got: %v", err)
+	}
+}
+
+// TestMultiDocCozystack_ValidClusterNameOverride ensures clusterName
+// overrides make it through to the result.
+func TestMultiDocCozystack_ValidClusterNameOverride(t *testing.T) {
+	result := renderCozystackWith(t, simpleNicLookup(), map[string]any{
+		"clusterName": "differentclustername",
+	})
+
+	assertContains(t, result, "clusterName: \"differentclustername\"")
+}
+
+// TestMultiDocGeneric_InvalidSubnetsFallsBackToDiscovery mirrors the
+// cozystack-side smoke test for ensuring invalid clusterName
+// overrides are rejected.
+func TestMultiDocGeneric_InvalidClusterNameOverride(t *testing.T) {
+	origLookup := helmEngine.LookupFunc
+	t.Cleanup(func() { helmEngine.LookupFunc = origLookup })
+	helmEngine.LookupFunc = simpleNicLookup()
+
+	chrt, err := loader.LoadDir("../../charts/generic")
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values := make(map[string]any)
+	maps.Copy(values, chrt.Values)
+	values["clusterName"] = "InvalidClusterName"
+
+	eng := helmEngine.Engine{}
+	_, err = eng.Render(chrt, chartutil.Values{
+		"Values":       values,
+		"TalosVersion": "v1.12",
+	})
+	if err == nil {
+		t.Fatal("expected render to fail with required() error when clusterName is invalid")
+	}
+	if !strings.Contains(err.Error(), "clusterName") {
+		t.Errorf("error should mention 'clusterName'; got: %v", err)
+	}
+}
+
+// TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery mirrors the
+// cozystack-side smoke test for ensuring clusterName overrides make
+// it through to the result.
+func TestMultiDocGeneric_ValidClusterNameOverride(t *testing.T) {
+	result := renderGenericWith(t, simpleNicLookup(), map[string]any{
+		"clusterName": "differentclustername",
+	})
+
+	assertContains(t, result, "clusterName: \"differentclustername\"")
 }
 
 // TestMultiDocGeneric_ValidSubnetsFallsBackToDiscovery mirrors the


### PR DESCRIPTION
This allows users to override the generated cluster name in the case they don't want it to match the chart name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable cluster naming in Helm charts with automatic fallback to the chart name and enforced DNS-1123 validation (invalid names now produce an error).

* **Configuration**
  * Added optional clusterName chart value to override the default name.

* **Tests**
  * Rendering tests updated to validate override behavior and enforce quoted clusterName output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->