### PR TITLE
feat(init): add --image flag to override the preset values.yaml image

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ cd newcluster
 talm init -p cozystack -N myawesomecluster
 ```
 
+To pin a specific Talos installer image at init time (e.g. a [Talos Factory](https://factory.talos.dev/) image with extensions), pass `--image`:
+
+```bash
+talm init -p cozystack -N myawesomecluster --image factory.talos.dev/installer/<sha256>:<version>
+```
+
+`--image` rewrites the top-level `image:` field in the preset's `values.yaml` before write. The flag is honored on initial `init` only — for an existing project, edit `values.yaml` directly. The `cozystack` preset declares `image:`; the `generic` preset does not, so `--image --preset generic` is rejected up front.
+
 Edit `values.yaml` to set your cluster's control-plane endpoint. This is the URL every node's kubelet and kube-proxy will dial. The chart leaves it empty on purpose so a missed override fails loudly instead of silently embedding a placeholder. For cozystack VIP setups set `endpoint` and `floatingIP` together (same IP, single shared VIP); for single-node clusters use that node's routable IP and leave `floatingIP` blank; for multi-node with an external load balancer use the LB URL and leave `floatingIP` blank. When the VIP must sit on a link that does not yet exist on the live system at first apply (typically a VLAN sub-interface), set `vipLink` to that link name — the chart pins `Layer2VIPConfig.link` to it instead of the default-gateway link that discovery would otherwise pick, and emits the document even on a totally fresh node where no default-gateway link has been discovered yet. The chart does not auto-emit a `LinkConfig` or `VLANConfig` for the override link; the operator is responsible for ensuring the link comes up, typically by adding a `LinkConfig` or `VLANConfig` for that link to the per-node body overlay alongside `vipLink`. Subnet-selector fields (`kubelet.validSubnets`, `etcd.advertisedSubnets`) are derived automatically from the node's default-gateway-bearing link, so no override is needed unless you have a multi-homed node that requires a specific subnet pinned.
 
 Boot Talos Linux node, let's say it has address `192.0.2.4`. Then:

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -41,6 +42,7 @@ var initCmdFlags struct {
 	preset       string
 	name         string
 	talosVersion string
+	image        string
 	update       bool
 	encrypt      bool
 	decrypt      bool
@@ -55,6 +57,14 @@ var initCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("talos-version") {
 			initCmdFlags.talosVersion = Config.TemplateOptions.TalosVersion
+		}
+
+		// --image rewrites the preset's values.yaml at write time, so it
+		// only makes sense on initial init. Combining it with --encrypt /
+		// --decrypt / --update would let the flag silently disappear —
+		// surface the mismatch up front instead.
+		if initCmdFlags.image != "" && (initCmdFlags.encrypt || initCmdFlags.decrypt || initCmdFlags.update) {
+			return fmt.Errorf("--image is honored on initial init only; not valid with --encrypt, --decrypt, or --update")
 		}
 
 		// For -e, -d, and -u flags, always check that we're in a project root
@@ -410,15 +420,29 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to get preset files: %w", err)
 		}
 
+		// Validate --image up-front so a flag/preset mismatch fails
+		// the command before any file is written.
+		if err := validateImageOverride(presetFiles, initCmdFlags.preset, initCmdFlags.image); err != nil {
+			return err
+		}
+
 		for path, content := range presetFiles {
 			parts := strings.SplitN(path, "/", 2)
 			chartName := parts[0]
 			// Write preset files
 			if chartName == initCmdFlags.preset {
 				file := filepath.Join(Config.RootDir, filepath.Join(parts[1:]...))
-				if parts[len(parts)-1] == "Chart.yaml" {
+				switch parts[len(parts)-1] {
+				case "Chart.yaml":
 					err = writeToDestination(fmt.Appendf(nil, content, clusterName, Config.InitOptions.Version), file, 0o644)
-				} else {
+				case "values.yaml":
+					var rendered []byte
+					rendered, err = applyImageOverride([]byte(content), initCmdFlags.image)
+					if err != nil {
+						return err
+					}
+					err = writeToDestination(rendered, file, 0o644)
+				default:
 					err = writeToDestination([]byte(content), file, 0o644)
 				}
 				if err != nil {
@@ -487,6 +511,72 @@ func readChartYamlPreset() (string, error) {
 	}
 
 	return "", fmt.Errorf("preset not found in Chart.yaml dependencies")
+}
+
+// imageLineRe matches the top-level `image:` line in a preset
+// values.yaml regardless of YAML serialization style — double-quoted,
+// single-quoted, unquoted, with or without a trailing comment.
+// Line-anchored (?m)^image:…$ so a nested key, indented entry, or
+// commented `# image:` line is never substituted.
+var imageLineRe = regexp.MustCompile(`(?m)^image:.*$`)
+
+// applyImageOverride returns values with the top-level `image:` line
+// replaced so it points at override. An empty override returns values
+// unchanged. When override is non-empty but values has no top-level
+// `image:` line, the helper returns an error rather than silently
+// dropping the user's flag — a preset that does not declare an image
+// field cannot be customized through this path, and the caller must
+// surface that to the user before any file is written.
+//
+// The override is %q-quoted, which Go-escapes special characters and
+// emits a double-quoted string. The substitution goes through
+// ReplaceAllFunc rather than ReplaceAll because the latter expands
+// `$0` / `$1` / `$name` / `${name}` sequences in the replacement —
+// an image reference like `foo/$tenant/bar` would otherwise be
+// rewritten to a different image, silently. ReplaceAllFunc returns
+// the byte slice verbatim with no $-expansion.
+//
+// The regex matches every top-level `image:` line via ReplaceAllFunc,
+// so a preset that ever declares two top-level image fields would have
+// both rewritten to the same value. Today only `cozystack` has one
+// occurrence; a future preset that breaks this assumption surfaces
+// here as a behaviour change worth catching at review.
+func applyImageOverride(values []byte, override string) ([]byte, error) {
+	if override == "" {
+		return values, nil
+	}
+	if !imageLineRe.Match(values) {
+		return nil, fmt.Errorf("--image was set but the preset values.yaml does not declare a top-level image: field; remove --image, choose a different preset, or add the image field manually")
+	}
+	replacement := fmt.Appendf(nil, "image: %q", override)
+	return imageLineRe.ReplaceAllFunc(values, func([]byte) []byte {
+		return replacement
+	}), nil
+}
+
+// validateImageOverride scans presetFiles for the chosen preset's
+// values.yaml and confirms a top-level image line is present when
+// the user passed --image. The check runs before any file is written
+// so a flag-vs-preset mismatch fails the command up front instead of
+// leaving a half-initialized project on disk.
+func validateImageOverride(presetFiles map[string]string, presetName, override string) error {
+	if override == "" {
+		return nil
+	}
+	for path, content := range presetFiles {
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) != 2 || parts[0] != presetName {
+			continue
+		}
+		if parts[1] != "values.yaml" {
+			continue
+		}
+		if !imageLineRe.Match([]byte(content)) {
+			return fmt.Errorf("--image was set but preset %q does not declare a top-level image: field in values.yaml; remove --image or choose a preset that exposes it (e.g. cozystack)", presetName)
+		}
+		return nil
+	}
+	return fmt.Errorf("--image was set but preset %q has no values.yaml in the embedded chart files", presetName)
 }
 
 // askUserOverwrite asks user if they want to overwrite a file
@@ -586,6 +676,14 @@ func updateFileWithConfirmation(filePath string, newContent []byte, permissions 
 }
 
 func updateTalmLibraryChart() error {
+	// --image is only honored on initial init (it customizes the
+	// preset's values.yaml at write time). Refusing it on --update
+	// surfaces the no-op trap explicitly instead of letting the
+	// user's flag silently disappear.
+	if initCmdFlags.image != "" {
+		return fmt.Errorf("--image is honored on initial init only; for an existing project, edit the image field in values.yaml directly")
+	}
+
 	// Determine preset: use -p flag if provided, otherwise try to read from Chart.yaml
 	var presetName string
 
@@ -680,6 +778,7 @@ func init() {
 	initCmd.Flags().StringVar(&initCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
 	initCmd.Flags().StringVarP(&initCmdFlags.preset, "preset", "p", "", "preset for file generation (not required with --encrypt, --decrypt, or --update)")
 	initCmd.Flags().StringVarP(&initCmdFlags.name, "name", "N", "", "cluster name (not required with --encrypt, --decrypt, or --update)")
+	initCmd.Flags().StringVar(&initCmdFlags.image, "image", "", "override the Talos installer image written to the preset's values.yaml (e.g. factory.talos.dev/installer/<sha256>:<version>)")
 	initCmd.Flags().BoolVar(&initCmdFlags.force, "force", false, "will overwrite existing files")
 	initCmd.Flags().BoolVarP(&initCmdFlags.update, "update", "u", false, "update Talm library chart")
 	// Override persistent -e flag for init command to use for encrypt

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -545,6 +545,12 @@ func applyImageOverride(values []byte, override string) ([]byte, error) {
 	if override == "" {
 		return values, nil
 	}
+	// In the talm init flow this guard is redundant: RunE invokes
+	// validateImageOverride against the same byte content from
+	// presetFiles before this loop runs, so a missing image: field
+	// fails the command up front. The check is kept as defense in
+	// depth for direct callers (unit tests, future code paths that
+	// might skip the validator) so the helper is safe in isolation.
 	if !imageLineRe.Match(values) {
 		return nil, fmt.Errorf("--image was set but the preset values.yaml does not declare a top-level image: field; remove --image, choose a different preset, or add the image field manually")
 	}

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -577,7 +577,7 @@ func validateImageOverride(presetFiles map[string]string, presetName, override s
 		if parts[1] != "values.yaml" {
 			continue
 		}
-		if !imageLineRe.Match([]byte(content)) {
+		if !imageLineRe.MatchString(content) {
 			return fmt.Errorf("--image was set but preset %q does not declare a top-level image: field in values.yaml; remove --image or choose a preset that exposes it (e.g. cozystack)", presetName)
 		}
 		return nil

--- a/pkg/commands/init_test.go
+++ b/pkg/commands/init_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // writeToDestinationSilentOnFailureCases asserts neither writeTo-
@@ -105,6 +107,255 @@ func TestWriteToDestination_AnnouncesOnSuccess(t *testing.T) {
 
 // compile-time assert createdSink is writer-shaped.
 var _ io.Writer = (*bytes.Buffer)(nil)
+
+// TestApplyImageOverride pins the contract of the values.yaml image
+// substitution that backs `talm init --image <ref>`: an empty override
+// is a no-op, a non-empty override replaces the top-level `image:`
+// line with the user's reference and preserves surrounding content,
+// and a values.yaml without an `image:` field returns an error so the
+// caller can surface the flag/preset mismatch instead of silently
+// dropping --image.
+func TestApplyImageOverride(t *testing.T) {
+	original := []byte(`# Cluster endpoint.
+endpoint: ""
+
+floatingIP: ""
+
+# Optional override for the link Layer2VIPConfig is pinned to.
+vipLink: ""
+
+image: "ghcr.io/cozystack/cozystack/talos:v1.12.6"
+podSubnets:
+- 10.244.0.0/16
+`)
+
+	t.Run("empty override returns input unchanged", func(t *testing.T) {
+		got, err := applyImageOverride(original, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, original) {
+			t.Errorf("empty override mutated the input:\n%s", got)
+		}
+	})
+
+	t.Run("non-empty override replaces the image line", func(t *testing.T) {
+		got, err := applyImageOverride(original, "factory.talos.dev/installer/abc:v1.13.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := `image: "factory.talos.dev/installer/abc:v1.13.0"`
+		if !bytes.Contains(got, []byte(want)) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+		if bytes.Contains(got, []byte("ghcr.io/cozystack/cozystack/talos:v1.12.6")) {
+			t.Errorf("original image still present after override:\n%s", got)
+		}
+		for _, marker := range []string{
+			"# Cluster endpoint.",
+			"floatingIP: \"\"",
+			"vipLink: \"\"",
+			"podSubnets:",
+			"- 10.244.0.0/16",
+		} {
+			if !bytes.Contains(got, []byte(marker)) {
+				t.Errorf("override stripped surrounding content %q:\n%s", marker, got)
+			}
+		}
+	})
+
+	t.Run("values without image field returns an error", func(t *testing.T) {
+		noImage := []byte("endpoint: \"https://10.0.0.1:6443\"\nfloatingIP: \"\"\n")
+		_, err := applyImageOverride(noImage, "factory.talos.dev/installer/abc:v1.13.0")
+		if err == nil {
+			t.Fatal("expected an error when --image is set but values.yaml has no image: field; silent no-op would lose the user's flag")
+		}
+		if !strings.Contains(err.Error(), "image:") {
+			t.Errorf("error should name the missing field so the user knows what to do, got: %v", err)
+		}
+	})
+
+	t.Run("supports unquoted, single-quoted, and trailing-comment styles", func(t *testing.T) {
+		styles := []struct {
+			name string
+			in   string
+		}{
+			{"double-quoted", `image: "ghcr.io/foo:v1"` + "\n"},
+			{"single-quoted", `image: 'ghcr.io/foo:v1'` + "\n"},
+			{"unquoted", "image: ghcr.io/foo:v1\n"},
+			{"trailing-comment", `image: "ghcr.io/foo:v1" # default` + "\n"},
+		}
+		for _, s := range styles {
+			t.Run(s.name, func(t *testing.T) {
+				got, err := applyImageOverride([]byte(s.in), "factory.talos.dev/installer/abc:v1.13.0")
+				if err != nil {
+					t.Fatalf("unexpected error on %s style: %v", s.name, err)
+				}
+				if bytes.Contains(got, []byte("ghcr.io/foo:v1")) {
+					t.Errorf("original image survived on %s style:\n%s", s.name, got)
+				}
+				if !bytes.Contains(got, []byte(`image: "factory.talos.dev/installer/abc:v1.13.0"`)) {
+					t.Errorf("override missing on %s style:\n%s", s.name, got)
+				}
+			})
+		}
+	})
+
+	t.Run("override containing dollar sequences round-trips verbatim", func(t *testing.T) {
+		// regexp.ReplaceAll expands $0 / $1 / $name / ${name} in the
+		// replacement, so a naive helper would silently corrupt an
+		// image reference like factory.talos.dev/$tenant/foo:v1 (the
+		// $tenant segment would resolve to an empty backreference and
+		// disappear). The helper goes through ReplaceAllFunc instead
+		// so the override bytes are written verbatim. Pin every
+		// expansion form that regexp.Expand recognizes so a future
+		// switch back to ReplaceAll is caught here.
+		dollarCases := []string{
+			`factory.talos.dev/$tenant/foo:v1`,
+			`factory.talos.dev/$0/foo:v1`,
+			`factory.talos.dev/${name}/foo:v1`,
+			`factory.talos.dev/installer$1foo:v1`,
+		}
+		for _, override := range dollarCases {
+			t.Run(override, func(t *testing.T) {
+				got, err := applyImageOverride(original, override)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				var parsed struct {
+					Image string `yaml:"image"`
+				}
+				if err := yaml.Unmarshal(got, &parsed); err != nil {
+					t.Fatalf("yaml.Unmarshal failed on helper output: %v\n%s", err, got)
+				}
+				if parsed.Image != override {
+					t.Errorf("override with $-sequence round-trip mismatch: got image=%q, want %q\nhelper output:\n%s", parsed.Image, override, got)
+				}
+			})
+		}
+	})
+
+	t.Run("output round-trips through yaml.Unmarshal", func(t *testing.T) {
+		// Pin that the override produces a YAML string the parser
+		// reads back as the original input — no escape-sequence
+		// surprises from %q quoting.
+		got, err := applyImageOverride(original, "factory.talos.dev/installer/abc:v1.13.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var parsed struct {
+			Image string `yaml:"image"`
+		}
+		if err := yaml.Unmarshal(got, &parsed); err != nil {
+			t.Fatalf("yaml.Unmarshal failed on helper output: %v\n%s", err, got)
+		}
+		if parsed.Image != "factory.talos.dev/installer/abc:v1.13.0" {
+			t.Errorf("round-trip mismatch: got image=%q, want %q", parsed.Image, "factory.talos.dev/installer/abc:v1.13.0")
+		}
+	})
+}
+
+// TestInitPreRunRejectsImageWithExclusiveModes pins the up-front
+// rejection of --image when combined with --encrypt, --decrypt, or
+// --update. Without it, the flag silently no-ops on those paths
+// (they early-return before the preset write loop runs) and the user
+// has no signal that their intent was discarded.
+func TestInitPreRunRejectsImageWithExclusiveModes(t *testing.T) {
+	imageOrig := initCmdFlags.image
+	encryptOrig := initCmdFlags.encrypt
+	decryptOrig := initCmdFlags.decrypt
+	updateOrig := initCmdFlags.update
+	t.Cleanup(func() {
+		initCmdFlags.image = imageOrig
+		initCmdFlags.encrypt = encryptOrig
+		initCmdFlags.decrypt = decryptOrig
+		initCmdFlags.update = updateOrig
+	})
+
+	cases := []struct {
+		name string
+		set  func()
+	}{
+		{"encrypt", func() { initCmdFlags.encrypt = true }},
+		{"decrypt", func() { initCmdFlags.decrypt = true }},
+		{"update", func() { initCmdFlags.update = true }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			initCmdFlags.image = "factory.talos.dev/installer/abc:v1.13.0"
+			initCmdFlags.encrypt = false
+			initCmdFlags.decrypt = false
+			initCmdFlags.update = false
+			tc.set()
+
+			err := initCmd.PreRunE(initCmd, nil)
+			if err == nil {
+				t.Fatalf("expected --image with --%s to error in PreRunE", tc.name)
+			}
+			if !strings.Contains(err.Error(), "--image") {
+				t.Errorf("error must name --image so the user can act on it, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestUpdateTalmLibraryChartRejectsImageFlag pins that --image is
+// honored on initial init only. Letting it slip through --update
+// would silently no-op (the update path does not touch the project's
+// existing values.yaml content), losing the user's flag — same UX
+// trap the validation in init proper exists to prevent.
+func TestUpdateTalmLibraryChartRejectsImageFlag(t *testing.T) {
+	imageOrig := initCmdFlags.image
+	t.Cleanup(func() { initCmdFlags.image = imageOrig })
+
+	initCmdFlags.image = "factory.talos.dev/installer/abc:v1.13.0"
+	err := updateTalmLibraryChart()
+	if err == nil {
+		t.Fatal("expected --update to reject --image; got nil error")
+	}
+	if !strings.Contains(err.Error(), "--image") {
+		t.Errorf("error must name --image so the user can act on it, got: %v", err)
+	}
+}
+
+// TestValidateImageOverride pins the up-front mismatch detection that
+// runs in initCmd.RunE before any file is written: --image must be
+// rejected when the chosen preset has no top-level image: field, so
+// the user does not end up with a half-written project that silently
+// dropped the flag.
+func TestValidateImageOverride(t *testing.T) {
+	preset := map[string]string{
+		"good/values.yaml":  "image: \"original\"\n",
+		"good/Chart.yaml":   "name: good\n",
+		"empty/values.yaml": "endpoint: \"https://example.invalid\"\n",
+		"empty/Chart.yaml":  "name: empty\n",
+	}
+
+	t.Run("empty override skips validation", func(t *testing.T) {
+		if err := validateImageOverride(preset, "good", ""); err != nil {
+			t.Errorf("empty override must not error, got: %v", err)
+		}
+		if err := validateImageOverride(preset, "empty", ""); err != nil {
+			t.Errorf("empty override must not error on a preset without image: either, got: %v", err)
+		}
+	})
+
+	t.Run("override on preset with image: passes", func(t *testing.T) {
+		if err := validateImageOverride(preset, "good", "factory.talos.dev/installer/abc:v1"); err != nil {
+			t.Errorf("validation failed on a preset that does declare image:, got: %v", err)
+		}
+	})
+
+	t.Run("override on preset without image: errors with preset name", func(t *testing.T) {
+		err := validateImageOverride(preset, "empty", "factory.talos.dev/installer/abc:v1")
+		if err == nil {
+			t.Fatal("expected an error when --image is set but preset has no image: field")
+		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Errorf("error should name the offending preset so the user can act on it, got: %v", err)
+		}
+	})
+}
 
 // TestWriteSecretsBundleToFile_StillRefusesOverwrite pins that
 // writeSecretsBundleToFile still honors the --force gate after the


### PR DESCRIPTION
## What changed

`talm init` writes the chosen preset chart unchanged, including the hard-coded installer image (the `cozystack` preset pins `ghcr.io/cozystack/cozystack/talos:v1.12.6`). Operators using a custom or factory-built Talos image have to edit `values.yaml` after every fresh init. The new `--image` flag makes the override declarative at init time:

```bash
talm init --preset cozystack --name cluster \
  --image factory.talos.dev/installer/<sha>:<version>
```

## How

- A line-anchored regex finds the top-level `image:` line in the preset's `values.yaml` and `ReplaceAllFunc` rewrites it. `ReplaceAllFunc` is used over `ReplaceAll` because the latter expands `$0` / `$1` / `$name` / `${name}` in the replacement, which would silently corrupt image refs containing `$`.
- `--image` is rejected up front in `PreRunE` when combined with `--encrypt`, `--decrypt`, or `--update` — the flag rewrites preset content at write time and silently no-ops on those paths otherwise.
- `validateImageOverride` runs in `RunE` before any file is written, so a flag/preset mismatch (e.g. `--image --preset generic`, since `generic` has no `image:` field) errors out before the project is half-initialized on disk.
- README updated with the new flag's usage and scope.

## Tests

- `applyImageOverride` covers: empty-override no-op, replacement preserving surrounding content, missing-field error, four quoting styles (double/single/unquoted/trailing-comment), four `$`-expansion forms (`$0`, `$1`, `$tenant`, `${name}`) round-tripping verbatim through `yaml.Unmarshal`.
- `validateImageOverride` covers happy + sad paths.
- `initCmd.PreRunE` rejects `--image` with each of `--encrypt`, `--decrypt`, `--update`.
- `updateTalmLibraryChart` defensively rejects `--image` for direct callers.

Closes #24.