### PR TITLE
feat(charts): centralise DNS-1123 subdomain validation in talm helper

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -98,12 +98,12 @@ cluster:
   network:
     cni:
       name: none
-    dnsDomain: {{ .Values.clusterDomain }}
+    dnsDomain: {{ include "talm.validate.dns1123subdomain" (dict "value" .Values.clusterDomain "field" "clusterDomain") }}
     podSubnets:
       {{- toYaml .Values.podSubnets | nindent 6 }}
     serviceSubnets:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
-  clusterName: {{ .Values.clusterName | default .Chart.Name | regexFind "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | required "clusterName must be a valid DNS-1123 label" | quote }}
+  clusterName: {{ include "talm.validate.dns1123subdomain" (dict "value" (.Values.clusterName | default .Chart.Name) "field" "clusterName") | quote }}
   controlPlane:
     endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP (cozystack floatingIP) or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}

--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -98,7 +98,7 @@ cluster:
   network:
     cni:
       name: none
-    dnsDomain: {{ include "talm.validate.dns1123subdomain" (dict "value" .Values.clusterDomain "field" "clusterDomain") }}
+    dnsDomain: {{ include "talm.validate.dns1123subdomain" (dict "value" .Values.clusterDomain "field" "clusterDomain") | quote }}
     podSubnets:
       {{- toYaml .Values.podSubnets | nindent 6 }}
     serviceSubnets:

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -52,7 +52,7 @@ cluster:
       {{- toYaml .Values.podSubnets | nindent 6 }}
     serviceSubnets:
       {{- toYaml .Values.serviceSubnets | nindent 6 }}
-  clusterName: {{ .Values.clusterName | default .Chart.Name | regexFind "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | required "clusterName must be a valid DNS-1123 label" | quote }}
+  clusterName: {{ include "talm.validate.dns1123subdomain" (dict "value" (.Values.clusterName | default .Chart.Name) "field" "clusterName") | quote }}
   controlPlane:
     endpoint: {{ required "values.yaml: `endpoint` must be set to the cluster control-plane URL (e.g. https://<vip>:6443). This field is cluster-wide: every node's kubelet and kube-proxy dials it, so it cannot be auto-derived from the current node's IP -- `talm template` runs once per node and has no way to reconcile per-node IPs into a single shared endpoint. For multi-node setups use a VIP or an external load balancer; for single-node clusters the node's routable IP works." .Values.endpoint | quote }}
   {{- if eq .MachineType "controlplane" }}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -507,7 +507,7 @@ busPath: {{ $link.spec.busPath }}
 {{- $value := .value -}}
 {{- $field := .field -}}
 {{- if not $value -}}
-{{- fail (printf "values.yaml: %s must be a non-empty DNS-1123 subdomain (lowercase alphanumeric, '-', and '.'; total max 253 chars)" $field) -}}
+{{- fail (printf "values.yaml: %s must be a non-empty DNS-1123 subdomain (must be lowercase, only [a-z0-9-.], start and end with [a-z0-9], max 253 chars)" $field) -}}
 {{- end -}}
 {{- if gt (len $value) 253 -}}
 {{- fail (printf "values.yaml: %s=%q exceeds 253 characters (DNS-1123 subdomain length limit)" $field $value) -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -475,3 +475,45 @@ vlans:
 busPath: {{ $link.spec.busPath }}
 {{- end -}}
 {{- end -}}
+
+{{- /* Validate that a value is a well-formed DNS-1123 subdomain
+       (RFC 1035 syntax + RFC 1123 leading-digit relaxation). On
+       success returns the value verbatim so callers can pipe it
+       into `quote` or use it inline. On any violation fails the
+       render with a precise message naming the field and the
+       offending value.
+
+       Mirrors what k8s.io/apimachinery/pkg/util/validation
+       .IsDNS1123Subdomain enforces in Go-side flag validation
+       (talm init --name) so chart-rendered values agree with
+       values an operator passes through the CLI:
+
+         1. non-empty
+         2. total length <= 253 chars
+         3. matches RFC 1123 subdomain regex (lowercase, only
+            [a-z0-9-.], each label starts/ends with [a-z0-9],
+            no double dots)
+
+       Per-label length (63 chars) is NOT enforced — upstream
+       IsDNS1123Subdomain does not enforce it either, and there
+       is no Talos-side cluster-name length cap that aligns with
+       a 63-char floor. Stay symmetric with Go-side validation.
+
+       Usage:
+           {{ include "talm.validate.dns1123subdomain"
+              (dict "value" .Values.clusterName "field" "clusterName") }}
+       */ -}}
+{{- define "talm.validate.dns1123subdomain" -}}
+{{- $value := .value -}}
+{{- $field := .field -}}
+{{- if not $value -}}
+{{- fail (printf "values.yaml: %s must be a non-empty DNS-1123 subdomain (lowercase alphanumeric, '-', and '.'; total max 253 chars)" $field) -}}
+{{- end -}}
+{{- if gt (len $value) 253 -}}
+{{- fail (printf "values.yaml: %s=%q exceeds 253 characters (DNS-1123 subdomain length limit)" $field $value) -}}
+{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" $value) -}}
+{{- fail (printf "values.yaml: %s=%q is not a valid DNS-1123 subdomain (must be lowercase, only [a-z0-9-.], start and end with [a-z0-9])" $field $value) -}}
+{{- end -}}
+{{- $value -}}
+{{- end -}}

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -499,14 +499,20 @@ busPath: {{ $link.spec.busPath }}
        is no Talos-side cluster-name length cap that aligns with
        a 63-char floor. Stay symmetric with Go-side validation.
 
+       Coercion: .value is rendered through `printf "%v"` before
+       length / regex checks so an unquoted numeric YAML scalar
+       (e.g. `clusterName: 123`) becomes the string "123" instead
+       of crashing the template at `len of type int`. The eq-""
+       emptiness check also avoids treating numeric 0 as falsy.
+
        Usage:
            {{ include "talm.validate.dns1123subdomain"
               (dict "value" .Values.clusterName "field" "clusterName") }}
        */ -}}
 {{- define "talm.validate.dns1123subdomain" -}}
-{{- $value := .value -}}
 {{- $field := .field -}}
-{{- if not $value -}}
+{{- $value := printf "%v" .value -}}
+{{- if eq $value "" -}}
 {{- fail (printf "values.yaml: %s must be a non-empty DNS-1123 subdomain (must be lowercase, only [a-z0-9-.], start and end with [a-z0-9], max 253 chars)" $field) -}}
 {{- end -}}
 {{- if gt (len $value) 253 -}}

--- a/pkg/commands/contract_init_validation_test.go
+++ b/pkg/commands/contract_init_validation_test.go
@@ -1,0 +1,160 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract: `talm init --name <X>` validates X as a DNS-1123
+// subdomain in PreRunE before any file is written. The check uses
+// k8s.io/apimachinery/pkg/util/validation.IsDNS1123Subdomain so the
+// error wording, character class, and length limits match the
+// upstream Kubernetes contract that the rendered Talos config
+// downstream relies on.
+
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// withInitFlagsSnapshot captures the package-level initCmdFlags so a
+// test can mutate them without leaking into subsequent tests.
+func withInitFlagsSnapshot(t *testing.T) {
+	t.Helper()
+	saved := initCmdFlags
+	t.Cleanup(func() { initCmdFlags = saved })
+}
+
+// Contract: a valid DNS-1123 subdomain passes PreRunE without
+// touching the validation guard. Includes single-label, multi-label
+// (`my.cluster.example`), leading-digit, dashes-in-the-middle. The
+// shipped chart names (`cozystack`, `generic`, `talm`) ALL must
+// pass — they are valid by construction, so a regression in the
+// validator that rejected them would brick every default install.
+func TestContract_InitPreRun_AcceptsValidDNS1123Subdomain(t *testing.T) {
+	withInitFlagsSnapshot(t)
+
+	cases := []string{
+		"cozystack",
+		"generic",
+		"talm",
+		"my-cluster",
+		"my.cluster.example",
+		"1leading-digit",
+		"a",      // single character
+		"prod-2", // trailing digit
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			initCmdFlags.preset = "cozystack"
+			initCmdFlags.name = name
+			initCmdFlags.encrypt = false
+			initCmdFlags.decrypt = false
+			initCmdFlags.update = false
+			initCmdFlags.image = ""
+			if err := initCmd.PreRunE(initCmd, nil); err != nil {
+				t.Errorf("expected %q to pass PreRunE, got: %v", name, err)
+			}
+		})
+	}
+}
+
+// Contract: an invalid DNS-1123 subdomain is rejected in PreRunE
+// with an error that names the offending value AND includes the
+// upstream k8s validator message (so the operator sees the precise
+// constraint that was violated). Each row covers a distinct
+// failure class so a regression that loosens the validator only on
+// some axis surfaces here.
+func TestContract_InitPreRun_RejectsInvalidDNS1123Subdomain(t *testing.T) {
+	withInitFlagsSnapshot(t)
+
+	cases := []struct {
+		name        string
+		clusterName string
+		expectInMsg string // substring of the k8s validator message
+	}{
+		{"uppercase", "MyCluster", "lower case"},
+		{"underscore", "my_cluster", "alphanumeric"},
+		{"leading dash", "-bad", "alphanumeric"},
+		{"trailing dash", "bad-", "alphanumeric"},
+		{"space", "my cluster", "alphanumeric"},
+		{"empty label between dots", "foo..bar", "alphanumeric"},
+		{"subdomain too long", strings.Repeat("a", 254), "253"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			initCmdFlags.preset = "cozystack"
+			initCmdFlags.name = tc.clusterName
+			initCmdFlags.encrypt = false
+			initCmdFlags.decrypt = false
+			initCmdFlags.update = false
+			initCmdFlags.image = ""
+
+			err := initCmd.PreRunE(initCmd, nil)
+			if err == nil {
+				t.Fatalf("expected %q to fail PreRunE", tc.clusterName)
+			}
+			if !strings.Contains(err.Error(), `"`+tc.clusterName+`"`) {
+				t.Errorf("error must quote the offending value, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "DNS-1123 subdomain") {
+				t.Errorf("error must mention 'DNS-1123 subdomain' for grep-ability, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.expectInMsg) {
+				t.Errorf("error must include upstream substring %q, got: %v", tc.expectInMsg, err)
+			}
+		})
+	}
+}
+
+// Contract: validation runs ONLY when --name applies — under
+// --encrypt / --decrypt / --update the name flag is not required, so
+// the validator must not fire on an empty initCmdFlags.name. Pin
+// so a regression that always validates would break the
+// regenerate-talosconfig flow operators rely on (they pass --decrypt
+// without --name).
+//
+// These modes also require an existing project root, so the test
+// stages a fixture with Chart.yaml + secrets.yaml inside a tempdir
+// and points Config.RootDir at it. Without the project-root setup
+// PreRunE fails earlier than the validator can be reached.
+func TestContract_InitPreRun_SkipsValidationOnExclusiveModes(t *testing.T) {
+	withInitFlagsSnapshot(t)
+
+	cases := []struct {
+		name string
+		set  func()
+	}{
+		{"encrypt", func() { initCmdFlags.encrypt = true }},
+		{"decrypt", func() { initCmdFlags.decrypt = true }},
+		{"update", func() { initCmdFlags.update = true }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			makeProjectRoot(t, dir)
+			setRoot(t, dir)
+
+			initCmdFlags.preset = ""
+			initCmdFlags.name = ""
+			initCmdFlags.encrypt = false
+			initCmdFlags.decrypt = false
+			initCmdFlags.update = false
+			initCmdFlags.image = ""
+			tc.set()
+
+			if err := initCmd.PreRunE(initCmd, nil); err != nil {
+				t.Errorf("expected --%s with empty name to pass PreRunE, got: %v", tc.name, err)
+			}
+		})
+	}
+}

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -35,6 +35,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 var initCmdFlags struct {
@@ -100,6 +101,15 @@ var initCmd = &cobra.Command{
 		}
 		if initCmdFlags.name == "" {
 			return fmt.Errorf("cluster name is required (use --name or -N flag)")
+		}
+		// Validate the operator-supplied cluster name against the same
+		// DNS-1123 subdomain rule the chart helpers enforce at render
+		// time. Without this check an invalid name reaches the bundle
+		// generator and surfaces as an opaque downstream error; pinning
+		// it here means the operator sees the precise upstream message
+		// (length, character class, etc.) before any file is written.
+		if errs := validation.IsDNS1123Subdomain(initCmdFlags.name); len(errs) > 0 {
+			return fmt.Errorf("--name %q is not a valid DNS-1123 subdomain: %s", initCmdFlags.name, strings.Join(errs, "; "))
 		}
 		return nil
 	},

--- a/pkg/engine/contract_cluster_test.go
+++ b/pkg/engine/contract_cluster_test.go
@@ -237,7 +237,7 @@ func TestContract_Cluster_ClusterDomain_Cozystack(t *testing.T) {
 	for _, cell := range cozystackCells() {
 		t.Run(cell.name, func(t *testing.T) {
 			out := renderChartTemplate(t, cell.chartPath, cell.templateFile, cell.talosVersion)
-			assertContains(t, out, "dnsDomain: cozy.local")
+			assertContains(t, out, `dnsDomain: "cozy.local"`)
 		})
 	}
 }

--- a/pkg/engine/contract_dns1123_test.go
+++ b/pkg/engine/contract_dns1123_test.go
@@ -134,13 +134,16 @@ func TestContract_DNS1123_ClusterDomain_RejectsInvalid(t *testing.T) {
 }
 
 // Contract: the default cozy.local value passes validation
-// unchanged. A regression that tightened the regex would break
-// every fresh cozystack install.
+// unchanged and is rendered as a quoted string. The quote pin
+// guards against a value that happens to look numeric (e.g. a
+// subdomain consisting only of digits) being parsed as a YAML
+// number by downstream consumers; cluster names follow the same
+// quoting convention.
 func TestContract_DNS1123_ClusterDomain_DefaultPasses(t *testing.T) {
 	out := renderCozystackWith(t, helmEngineEmptyLookup, map[string]any{
 		"advertisedSubnets": []any{testAdvertisedSubnet},
 	})
-	assertContains(t, out, "dnsDomain: cozy.local")
+	assertContains(t, out, `dnsDomain: "cozy.local"`)
 }
 
 // === generic chart: same helper, same contract ===

--- a/pkg/engine/contract_dns1123_test.go
+++ b/pkg/engine/contract_dns1123_test.go
@@ -97,6 +97,58 @@ func TestContract_DNS1123_ClusterName_RejectsInvalid(t *testing.T) {
 	}
 }
 
+// Contract: an unquoted numeric YAML scalar (e.g. `clusterName: 123`
+// in values.yaml) is parsed by Helm as an int, not a string. The
+// helper coerces .value through `printf "%v"` before any length /
+// regex check, so the validator emits a normal DNS-1123 fail with
+// the field name and the stringified value instead of crashing the
+// template at `len of type int`. Pin so a regression that drops the
+// coercion surfaces here.
+func TestContract_DNS1123_ClusterName_NumericYAMLScalarCoerced(t *testing.T) {
+	err := renderExpectingError(t, cozystackChartPath, multidocTalos, helmEngineEmptyLookup, map[string]any{
+		"clusterName":       123,
+		"endpoint":          testEndpoint,
+		"advertisedSubnets": []any{testAdvertisedSubnet},
+	})
+	if err == nil {
+		// Note: "123" is actually a valid DNS-1123 subdomain (digits
+		// are allowed). If the helper coerces correctly AND the value
+		// passes validation, the render succeeds — that is also
+		// acceptable. The bug we are pinning against is the
+		// `len of type int` crash; either successful render or a
+		// DNS-1123 fail is fine, the template panic is not.
+		return
+	}
+	if strings.Contains(err.Error(), "len of type int") {
+		t.Errorf("template crashed on numeric value instead of coercing to string; got: %v", err)
+	}
+}
+
+// Contract: an invalid numeric value (e.g. negative numbers render
+// with a leading dash, which DNS-1123 rejects) coerces and then
+// fails with the regular DNS-1123 message naming the field and
+// quoting the stringified value. Pin both the coercion AND the
+// downstream validator wiring.
+func TestContract_DNS1123_ClusterName_InvalidNumericFailsCleanly(t *testing.T) {
+	err := renderExpectingError(t, cozystackChartPath, multidocTalos, helmEngineEmptyLookup, map[string]any{
+		"clusterName":       -1,
+		"endpoint":          testEndpoint,
+		"advertisedSubnets": []any{testAdvertisedSubnet},
+	})
+	if err == nil {
+		t.Fatal("expected fail for clusterName=-1")
+	}
+	if strings.Contains(err.Error(), "len of type") {
+		t.Errorf("template crashed on numeric value; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "DNS-1123 subdomain") {
+		t.Errorf("expected DNS-1123 subdomain message after coercion, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "clusterName") {
+		t.Errorf("error must name 'clusterName' field, got: %v", err)
+	}
+}
+
 // === clusterDomain: helper applied (cozystack only) ===
 
 // Contract: cozystack's clusterDomain (network.dnsDomain) flows

--- a/pkg/engine/contract_dns1123_test.go
+++ b/pkg/engine/contract_dns1123_test.go
@@ -1,0 +1,166 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract: the talm.validate.dns1123subdomain helper in
+// charts/talm/templates/_helpers.tpl. Both shipped charts pipe
+// values.yaml clusterName and (cozystack only) clusterDomain through
+// it so chart-render-time validation stays symmetric with the Go-side
+// validation.IsDNS1123Subdomain check on `talm init --name`.
+//
+// Tests render the cozystack chart with crafted overrides and assert
+// on the returned error message — this exercises the same code path
+// users hit at runtime.
+
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// === clusterName: helper happy paths ===
+
+// Contract: the helper accepts every shape that should be valid:
+// single-label, multi-label, leading digit, dashes-in-the-middle,
+// single-character. The shipped chart names ("cozystack",
+// "generic", "talm") MUST pass — these are the default fallback
+// when values.yaml.clusterName is empty.
+func TestContract_DNS1123_ClusterName_HappyPaths(t *testing.T) {
+	cases := []string{
+		"cozystack",
+		"generic",
+		"my-cluster",
+		"my.cluster.example",
+		"1leading-digit",
+		"a", // single character
+		"prod-2",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := renderCozystackWith(t, helmEngineEmptyLookup, map[string]any{
+				"clusterName":       name,
+				"advertisedSubnets": []any{testAdvertisedSubnet},
+			})
+			assertContains(t, out, `clusterName: "`+name+`"`)
+		})
+	}
+}
+
+// === clusterName: helper rejection paths ===
+
+// Contract: every invalid shape fails the render with a message
+// that names the field, quotes the offending value, and identifies
+// the violation class so an operator can act without consulting
+// the chart source.
+func TestContract_DNS1123_ClusterName_RejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		wantInError string // substring that must appear in the failure message
+	}{
+		{"uppercase", "MyCluster", "DNS-1123 subdomain"},
+		{"underscore", "my_cluster", "DNS-1123 subdomain"},
+		{"leading dash", "-bad", "DNS-1123 subdomain"},
+		{"trailing dash", "bad-", "DNS-1123 subdomain"},
+		{"space", "my cluster", "DNS-1123 subdomain"},
+		{"empty label between dots", "foo..bar", "DNS-1123 subdomain"},
+		{"subdomain too long", strings.Repeat("a", 254), "253"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := renderExpectingError(t, cozystackChartPath, multidocTalos, helmEngineEmptyLookup, map[string]any{
+				"clusterName":       tc.clusterName,
+				"endpoint":          testEndpoint,
+				"advertisedSubnets": []any{testAdvertisedSubnet},
+			})
+			if err == nil {
+				t.Fatalf("expected render to fail for clusterName=%q", tc.clusterName)
+			}
+			if !strings.Contains(err.Error(), "clusterName") {
+				t.Errorf("error must name 'clusterName' field, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error must contain %q, got: %v", tc.wantInError, err)
+			}
+		})
+	}
+}
+
+// === clusterDomain: helper applied (cozystack only) ===
+
+// Contract: cozystack's clusterDomain (network.dnsDomain) flows
+// through the same validator. Pinning here closes the gap that
+// previously existed: clusterDomain was unvalidated so an invalid
+// value reached Talos and surfaced as an opaque downstream error.
+func TestContract_DNS1123_ClusterDomain_RejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name          string
+		clusterDomain string
+		wantInError   string
+	}{
+		{"uppercase", "Cozy.Local", "DNS-1123 subdomain"},
+		{"underscore", "cozy_local", "DNS-1123 subdomain"},
+		{"empty", "", "non-empty DNS-1123 subdomain"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := renderExpectingError(t, cozystackChartPath, multidocTalos, helmEngineEmptyLookup, map[string]any{
+				"clusterDomain":     tc.clusterDomain,
+				"endpoint":          testEndpoint,
+				"advertisedSubnets": []any{testAdvertisedSubnet},
+			})
+			if err == nil {
+				t.Fatalf("expected render to fail for clusterDomain=%q", tc.clusterDomain)
+			}
+			if !strings.Contains(err.Error(), "clusterDomain") {
+				t.Errorf("error must name 'clusterDomain' field, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error must contain %q, got: %v", tc.wantInError, err)
+			}
+		})
+	}
+}
+
+// Contract: the default cozy.local value passes validation
+// unchanged. A regression that tightened the regex would break
+// every fresh cozystack install.
+func TestContract_DNS1123_ClusterDomain_DefaultPasses(t *testing.T) {
+	out := renderCozystackWith(t, helmEngineEmptyLookup, map[string]any{
+		"advertisedSubnets": []any{testAdvertisedSubnet},
+	})
+	assertContains(t, out, "dnsDomain: cozy.local")
+}
+
+// === generic chart: same helper, same contract ===
+
+// Contract: generic chart pipes clusterName through the same
+// helper. Pin one negative case here so a regression that touches
+// only the cozystack template surfaces on generic too.
+func TestContract_DNS1123_GenericClusterName_RejectsInvalid(t *testing.T) {
+	err := renderExpectingError(t, genericChartPath, multidocTalos, helmEngineEmptyLookup, map[string]any{
+		"clusterName":       "Invalid_Name",
+		"endpoint":          testEndpoint,
+		"advertisedSubnets": []any{testAdvertisedSubnet},
+	})
+	if err == nil {
+		t.Fatal("expected render to fail")
+	}
+	if !strings.Contains(err.Error(), "clusterName") {
+		t.Errorf("error must name 'clusterName' field, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "DNS-1123 subdomain") {
+		t.Errorf("error must mention DNS-1123 subdomain, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Replace per-site inline regex validation of `values.yaml: clusterName` with a shared `talm.validate.dns1123subdomain` helper, apply it to `clusterDomain` (cozystack), and add Go-side validation of `talm init --name` against the same upstream Kubernetes contract.

Three input channels accept DNS-name values from the operator:

1. **`talm init --name <X>`** — Go path. Now validated in PreRunE via `k8s.io/apimachinery/pkg/util/validation.IsDNS1123Subdomain`. Previously accepted anything; failure surfaced downstream as an opaque bundle-generator error.
2. **`values.yaml: clusterName`** — Helm template path in cozystack and generic charts. Previously a per-site inline regex with a misleading "DNS-1123 label" message and no length cap. Now piped through `talm.validate.dns1123subdomain` which matches the same RFC 1123 subdomain regex as the upstream k8s validator, enforces total length ≤ 253 chars, and emits a precise message naming the field and quoting the offending value.
3. **`values.yaml: clusterDomain`** (cozystack only) — previously unvalidated. Same helper, same contract.

## Test coverage

- `pkg/commands/contract_init_validation_test.go` — every shipped chart name passes; uppercase, underscore, leading/trailing dash, space, double dot, 254-char length all rejected with messages quoting the offending value and naming "DNS-1123 subdomain". Validator skipped under `--encrypt` / `--decrypt` / `--update` where `--name` is not required.
- `pkg/engine/contract_dns1123_test.go` — helper accepts canonical happy paths (single label, multi-label, leading digit, single character); rejects every invalid shape with a message naming the field. Same negative set tested for `clusterDomain`. Default `cozy.local` still passes on cozystack. Generic chart shares one negative case to catch template-only regressions.

## Notes

Per-label length (63 chars per RFC 1035) intentionally NOT enforced — upstream `IsDNS1123Subdomain` does not enforce it, and there is no Talos-side cap that aligns with a 63-char floor. Stay symmetric with Go-side validation.

Closes the follow-ups raised on #148.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS-1123 subdomain validation for cluster names and domains to ensure proper formatting.

* **Improvements**
  * The `init --name` command now validates input upfront with detailed error messaging for invalid values.
  * Cluster domain values are now consistently validated across all chart templates.

* **Tests**
  * Added comprehensive validation test coverage for cluster naming and domain constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/talm/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->