### PR TITLE
fix: RotateKeys atomic rotation, debugPhase empty-patch guard, normalizeEndpoint IPv6 brackets

### DIFF
--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -483,7 +483,10 @@ func decryptString(encryptedBase64 string, identity *age.X25519Identity) (string
 
 // RotateKeys rotates encryption keys in secrets.encrypted.yaml
 func RotateKeys(rootDir string) error {
-	// Load old key first (before generating new one)
+	// Load old key first (before retiring it). The old identity is
+	// kept in memory only — once the talm.key file is removed below,
+	// the key material exists only here for the duration of the
+	// re-encrypt pass, then goes out of scope.
 	oldIdentity, err := LoadKey(rootDir)
 	if err != nil {
 		return fmt.Errorf("failed to load old key: %w", err)
@@ -508,7 +511,17 @@ func RotateKeys(rootDir string) error {
 		return fmt.Errorf("failed to decrypt with old key: %w", err)
 	}
 
-	// Generate new key (this overwrites talm.key)
+	// Retire the old key: GenerateKey is a load-or-create helper, so
+	// without removing talm.key first it would re-load the old
+	// identity instead of generating a fresh one — and "rotation"
+	// would become a no-op that leaves the same key encrypting every
+	// secret. Remove it first, then generate so a new identity is
+	// guaranteed to land on disk.
+	keyFile := filepath.Join(rootDir, keyFileName)
+	if err := os.Remove(keyFile); err != nil {
+		return fmt.Errorf("failed to retire old key: %w", err)
+	}
+
 	newIdentity, _, err := GenerateKey(rootDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate new key: %w", err)

--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -227,8 +227,13 @@ func EncryptSecretsFile(rootDir string) error {
 		return fmt.Errorf("failed to marshal encrypted secrets: %w", err)
 	}
 
-	// Write encrypted file
-	if err := os.WriteFile(encryptedFile, encryptedData, 0o644); err != nil {
+	// Write encrypted file via secureperm.WriteFile so it lands at
+	// mode 0o600 (defense-in-depth — age encryption is the security
+	// layer, but world-readable secrets material on shared
+	// workstations invites mistakes). RotateKeys uses the same
+	// helper for the same file, keeping the on-disk mode invariant
+	// across every code path that writes secrets.encrypted.yaml.
+	if err := secureperm.WriteFile(encryptedFile, encryptedData); err != nil {
 		return fmt.Errorf("failed to write encrypted file: %w", err)
 	}
 
@@ -713,8 +718,11 @@ func EncryptYAMLFile(rootDir, plainFile, encryptedFile string) error {
 		return fmt.Errorf("failed to marshal encrypted YAML: %w", err)
 	}
 
-	// Write encrypted file
-	if err := os.WriteFile(encryptedFilePath, encryptedData, 0o644); err != nil {
+	// Write encrypted file via secureperm.WriteFile (mode 0o600).
+	// Same defense-in-depth rationale as EncryptSecretsFile and
+	// RotateKeys — every code path that writes encrypted secrets
+	// material agrees on the same on-disk permission.
+	if err := secureperm.WriteFile(encryptedFilePath, encryptedData); err != nil {
 		return fmt.Errorf("failed to write encrypted file: %w", err)
 	}
 

--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -59,19 +59,25 @@ func GenerateKey(rootDir string) (*age.X25519Identity, bool, error) {
 		return nil, false, fmt.Errorf("failed to generate age identity: %w", err)
 	}
 
-	publicKey := identity.Recipient().String()
-
-	// Format key file in age keygen format
-	now := time.Now()
-	keyData := fmt.Sprintf("# created: %s\n", now.Format(time.RFC3339))
-	keyData += fmt.Sprintf("# public key: %s\n", publicKey)
-	keyData += identity.String() + "\n"
-
-	if err := secureperm.WriteFile(keyFile, []byte(keyData)); err != nil {
+	if err := secureperm.WriteFile(keyFile, []byte(formatKeyFile(identity, time.Now()))); err != nil {
 		return nil, false, fmt.Errorf("failed to write key file: %w", err)
 	}
 
 	return identity, true, nil
+}
+
+// formatKeyFile renders the canonical age keygen layout: a creation
+// timestamp comment, a public key comment, and the AGE-SECRET-KEY-1
+// secret line, each terminated by a newline. Extracted from
+// GenerateKey so RotateKeys can produce the same layout for the
+// new identity it generates in memory.
+func formatKeyFile(identity *age.X25519Identity, now time.Time) string {
+	return fmt.Sprintf(
+		"# created: %s\n# public key: %s\n%s\n",
+		now.Format(time.RFC3339),
+		identity.Recipient().String(),
+		identity.String(),
+	)
 }
 
 // LoadKey loads age identity from talm.key file
@@ -482,64 +488,125 @@ func decryptString(encryptedBase64 string, identity *age.X25519Identity) (string
 }
 
 // RotateKeys rotates encryption keys in secrets.encrypted.yaml
+// RotateKeys atomically rotates the age key encrypting
+// secrets.encrypted.yaml. The old key is replaced with a freshly
+// generated identity, and the secrets file is re-encrypted under
+// the new key.
+//
+// Atomicity strategy: every disk-mutating step uses os.Rename or
+// secureperm.WriteFile (which is itself atomic temp+rename). The
+// previous key+encrypted pair is renamed aside into
+// `*.rotation-backup` files BEFORE the new files are committed; if
+// any later step fails the originals are restored. The function
+// only returns nil after the new pair is committed AND the
+// backup files have been removed. Operators who find leftover
+// `*.rotation-backup` files after an interrupted run can safely
+// rename them back into place — the new files will not be in the
+// way (they were never committed).
+//
+// The function uses the secureperm.WriteFile helper for both the
+// new key file and the new encrypted secrets file so both end up
+// at mode 0o600 (defense-in-depth — age encryption is the security
+// layer, but world-readable secrets material on shared workstations
+// invites mistakes).
 func RotateKeys(rootDir string) error {
-	// Load old key first (before retiring it). The old identity is
-	// kept in memory only — once the talm.key file is removed below,
-	// the key material exists only here for the duration of the
-	// re-encrypt pass, then goes out of scope.
+	keyFile := filepath.Join(rootDir, keyFileName)
+	encryptedFile := filepath.Join(rootDir, encryptedSecretsFile)
+	keyBackup := keyFile + ".rotation-backup"
+	encryptedBackup := encryptedFile + ".rotation-backup"
+
+	// Refuse to start if a previous rotation was interrupted: the
+	// operator must inspect the leftover files and decide what to
+	// keep before another rotation runs. Otherwise this run would
+	// silently overwrite the recovery state.
+	for _, p := range []string{keyBackup, encryptedBackup} {
+		if _, err := os.Stat(p); err == nil {
+			return fmt.Errorf("found leftover rotation backup %q from a previous interrupted run; inspect and remove (or restore) before retrying", p)
+		}
+	}
+
+	// Phase 1: read and decrypt with old key, all in memory.
 	oldIdentity, err := LoadKey(rootDir)
 	if err != nil {
 		return fmt.Errorf("failed to load old key: %w", err)
 	}
-
-	// Decrypt with old key
-	encryptedFile := filepath.Join(rootDir, encryptedSecretsFile)
-
 	encryptedData, err := os.ReadFile(encryptedFile)
 	if err != nil {
 		return fmt.Errorf("failed to read encrypted file: %w", err)
 	}
-
 	var encryptedSecrets map[string]any
 	if err := yaml.Unmarshal(encryptedData, &encryptedSecrets); err != nil {
 		return fmt.Errorf("failed to parse encrypted YAML: %w", err)
 	}
-
-	// Decrypt values with old key
 	decryptedSecrets, err := decryptYAMLValues(encryptedSecrets, oldIdentity)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt with old key: %w", err)
 	}
 
-	// Retire the old key: GenerateKey is a load-or-create helper, so
-	// without removing talm.key first it would re-load the old
-	// identity instead of generating a fresh one — and "rotation"
-	// would become a no-op that leaves the same key encrypting every
-	// secret. Remove it first, then generate so a new identity is
-	// guaranteed to land on disk.
-	keyFile := filepath.Join(rootDir, keyFileName)
-	if err := os.Remove(keyFile); err != nil {
-		return fmt.Errorf("failed to retire old key: %w", err)
-	}
-
-	newIdentity, _, err := GenerateKey(rootDir)
+	// Phase 2: generate new identity and encrypt new ciphertext —
+	// still all in memory. No disk mutation yet.
+	newIdentity, err := age.GenerateX25519Identity()
 	if err != nil {
-		return fmt.Errorf("failed to generate new key: %w", err)
+		return fmt.Errorf("failed to generate new identity: %w", err)
 	}
-
-	// Encrypt with new key
 	encryptedSecretsNew, err := encryptYAMLValues(decryptedSecrets, newIdentity.Recipient())
 	if err != nil {
 		return fmt.Errorf("failed to encrypt with new key: %w", err)
 	}
-
 	encryptedDataNew, err := yaml.Marshal(encryptedSecretsNew)
 	if err != nil {
-		return fmt.Errorf("failed to marshal encrypted secrets: %w", err)
+		return fmt.Errorf("failed to marshal new encrypted secrets: %w", err)
 	}
 
-	if err := os.WriteFile(encryptedFile, encryptedDataNew, 0o644); err != nil {
-		return fmt.Errorf("failed to write encrypted file: %w", err)
+	// Phase 3: move originals aside as backups. Atomic rename, so
+	// either both originals exist as `*.rotation-backup` after this
+	// block or neither move took effect (for the second rename: we
+	// undo the first if it errors).
+	if err := os.Rename(keyFile, keyBackup); err != nil {
+		return fmt.Errorf("failed to back up key file before rotation: %w", err)
+	}
+	if err := os.Rename(encryptedFile, encryptedBackup); err != nil {
+		// Roll back the key rename so the project is untouched.
+		_ = os.Rename(keyBackup, keyFile)
+		return fmt.Errorf("failed to back up encrypted file before rotation: %w", err)
+	}
+
+	// restore is a recovery helper used when any later step fails:
+	// rename the backups back into place and return the original
+	// error wrapped with a recovery note. We never silently swallow
+	// the restore's own error — if recovery fails the operator
+	// needs to know.
+	restore := func(stage string, cause error) error {
+		_ = os.Remove(keyFile)       // best-effort: remove half-written new key if any
+		_ = os.Remove(encryptedFile) // ditto for encrypted file
+		errKey := os.Rename(keyBackup, keyFile)
+		errEnc := os.Rename(encryptedBackup, encryptedFile)
+		if errKey != nil || errEnc != nil {
+			return fmt.Errorf("rotation failed at %s: %w; AND restore from backup partially failed (key: %v, encrypted: %v) — manual recovery: rename %q -> %q and %q -> %q",
+				stage, cause, errKey, errEnc, keyBackup, keyFile, encryptedBackup, encryptedFile)
+		}
+		return fmt.Errorf("rotation failed at %s: %w (originals restored)", stage, cause)
+	}
+
+	// Phase 4: write new key, then new encrypted file. Both via
+	// secureperm.WriteFile (atomic + 0o600). On any failure the
+	// `restore` closure puts the originals back.
+	if err := secureperm.WriteFile(keyFile, []byte(formatKeyFile(newIdentity, time.Now()))); err != nil {
+		return restore("write new key", err)
+	}
+	if err := secureperm.WriteFile(encryptedFile, encryptedDataNew); err != nil {
+		return restore("write new encrypted file", err)
+	}
+
+	// Phase 5: rotation succeeded — remove backups. If removal
+	// fails we still return nil (the rotation itself is committed
+	// and verifiable on disk; leftover backups are an annoyance,
+	// not data loss). Log to stderr so the operator can clean up.
+	if err := os.Remove(keyBackup); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to remove %q after rotation: %v\n", keyBackup, err)
+	}
+	if err := os.Remove(encryptedBackup); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to remove %q after rotation: %v\n", encryptedBackup, err)
 	}
 
 	return nil

--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -497,31 +497,40 @@ func decryptString(encryptedBase64 string, identity *age.X25519Identity) (string
 // secureperm.WriteFile (which is itself atomic temp+rename). The
 // previous key+encrypted pair is renamed aside into
 // `*.rotation-backup` files BEFORE the new files are committed; if
-// any later step fails the originals are restored. The function
-// only returns nil after the new pair is committed AND the
-// backup files have been removed. Operators who find leftover
-// `*.rotation-backup` files after an interrupted run can safely
-// rename them back into place — the new files will not be in the
-// way (they were never committed).
+// any later step fails the originals are restored.
 //
-// The function uses the secureperm.WriteFile helper for both the
-// new key file and the new encrypted secrets file so both end up
-// at mode 0o600 (defense-in-depth — age encryption is the security
-// layer, but world-readable secrets material on shared workstations
-// invites mistakes).
+// The function returns nil only after the new pair is committed
+// AND both backup files have been removed. If either commit or
+// cleanup fails the function returns a non-nil error, so the only
+// state in which `*.rotation-backup` files outlive the call is
+// when the call ITSELF returned an error. Operators who find
+// leftover `*.rotation-backup` files in that state should:
+//
+//   - inspect both `talm.key` and the backup; if `talm.key` exists
+//     and is newer than the backup, rotation succeeded and only
+//     cleanup failed — remove the `*.rotation-backup` files;
+//   - otherwise rotation was interrupted before commit — rename
+//     the backups back into place to recover the original state.
+//
+// Both new files are written via secureperm.WriteFile so they end
+// up at mode 0o600 (defense-in-depth — age encryption is the
+// security layer, but world-readable secrets material on shared
+// workstations invites mistakes).
 func RotateKeys(rootDir string) error {
 	keyFile := filepath.Join(rootDir, keyFileName)
 	encryptedFile := filepath.Join(rootDir, encryptedSecretsFile)
 	keyBackup := keyFile + ".rotation-backup"
 	encryptedBackup := encryptedFile + ".rotation-backup"
 
-	// Refuse to start if a previous rotation was interrupted: the
-	// operator must inspect the leftover files and decide what to
-	// keep before another rotation runs. Otherwise this run would
-	// silently overwrite the recovery state.
+	// Refuse to start if leftover rotation backups exist — the
+	// operator must inspect them and decide what to keep before
+	// another rotation runs, otherwise this run would silently
+	// overwrite the recovery state. Both interrupted and
+	// successful-with-failed-cleanup states leave these files
+	// behind; the docstring above explains how to distinguish.
 	for _, p := range []string{keyBackup, encryptedBackup} {
 		if _, err := os.Stat(p); err == nil {
-			return fmt.Errorf("found leftover rotation backup %q from a previous interrupted run; inspect and remove (or restore) before retrying", p)
+			return fmt.Errorf("found leftover rotation backup %q from a previous run (either interrupted, or successful with a failed cleanup step); inspect and remove (or restore) before retrying", p)
 		}
 	}
 
@@ -598,15 +607,22 @@ func RotateKeys(rootDir string) error {
 		return restore("write new encrypted file", err)
 	}
 
-	// Phase 5: rotation succeeded — remove backups. If removal
-	// fails we still return nil (the rotation itself is committed
-	// and verifiable on disk; leftover backups are an annoyance,
-	// not data loss). Log to stderr so the operator can clean up.
+	// Phase 5: rotation committed — remove backups. If removal
+	// fails we return an error so the caller (and a future
+	// RotateKeys run) sees an unambiguous "rotation succeeded but
+	// backups linger" signal. The new pair on disk is correct and
+	// usable; the leftover backups must be removed manually before
+	// the next rotation can run (Phase 0 will refuse otherwise).
+	var cleanupErrs []string
 	if err := os.Remove(keyBackup); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to remove %q after rotation: %v\n", keyBackup, err)
+		cleanupErrs = append(cleanupErrs, fmt.Sprintf("%q: %v", keyBackup, err))
 	}
 	if err := os.Remove(encryptedBackup); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to remove %q after rotation: %v\n", encryptedBackup, err)
+		cleanupErrs = append(cleanupErrs, fmt.Sprintf("%q: %v", encryptedBackup, err))
+	}
+	if len(cleanupErrs) > 0 {
+		return fmt.Errorf("rotation committed (new key and encrypted file are on disk) but cleanup of backup files failed: %s; remove these files manually before the next rotation",
+			strings.Join(cleanupErrs, "; "))
 	}
 
 	return nil

--- a/pkg/age/age.go
+++ b/pkg/age/age.go
@@ -576,8 +576,15 @@ func RotateKeys(rootDir string) error {
 	}
 	if err := os.Rename(encryptedFile, encryptedBackup); err != nil {
 		// Roll back the key rename so the project is untouched.
-		_ = os.Rename(keyBackup, keyFile)
-		return fmt.Errorf("failed to back up encrypted file before rotation: %w", err)
+		// Capture the rollback error too — if it fails the
+		// operator is left with keyBackup but no keyFile, and the
+		// caller-facing error must say so explicitly (otherwise
+		// a Phase 0 refusal on retry would be the first sign of
+		// the partial state).
+		if rbErr := os.Rename(keyBackup, keyFile); rbErr != nil {
+			return fmt.Errorf("failed to back up encrypted file before rotation: %w; AND rollback of key-file rename failed: %v — manual recovery: rename %q -> %q", err, rbErr, keyBackup, keyFile)
+		}
+		return fmt.Errorf("failed to back up encrypted file before rotation: %w (key file rename rolled back)", err)
 	}
 
 	// restore is a recovery helper used when any later step fails:

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -494,25 +494,26 @@ func TestContract_Age_RotateKeys_NoLeftoverBackups(t *testing.T) {
 	}
 }
 
-// Contract: when the post-commit cleanup of `*.rotation-backup`
-// files fails (e.g. a permissions flip on the parent dir between
-// the commit and the os.Remove), RotateKeys returns a non-nil
-// error explaining "rotation committed but cleanup failed" and
-// instructing the operator to remove the leftovers manually
-// before the next rotation. The new key + encrypted file on disk
-// are still the rotated pair — only the backups linger.
+// Contract: when something already occupies a path the rotation
+// will need to use (here we stage a directory at the backup
+// destination), RotateKeys refuses immediately and leaves the
+// originals untouched on disk. The directory case is interesting
+// because os.Stat returns nil error for directories just as for
+// regular files, so the Phase 0 leftover-backup check fires and
+// rejects the run before any rename happens. Pinning that the
+// originals survive any such early refusal.
 //
-// Failure injection: chmod the project dir to 0o500 right before
-// the cleanup step would run. We approximate this by triggering
-// the cleanup-failed code path indirectly: stage a directory at
-// the backup path so os.Remove (which expects a regular file)
-// fails. This is brittle but the only injection point reachable
-// without modifying the function signature.
+// The genuine Phase 5 cleanup-failure path (where rotation
+// commits but os.Remove of a backup file errors) is not
+// reachable through public-API fault injection — it requires
+// either a chmod between Phase 4 and Phase 5 or a swap of the
+// backup file for a directory in the same window, neither of
+// which is exposed. The Phase 5 error wording is exercised by
+// inspection only (see the docstring of RotateKeys).
 //
-// Skipped under root because chmod-on-directory-content does not
-// constrain euid 0; the test would always succeed in unhelpful
-// ways.
-func TestContract_Age_RotateKeys_CleanupFailureSurfacesError(t *testing.T) {
+// Skipped under root because directory permissions used in
+// adjacent injection paths are ignored by the kernel for euid 0.
+func TestContract_Age_RotateKeys_RefusesWhenDirectoryBlocksBackupPath(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root — directory permissions and os.Remove behaviour differ")
 	}
@@ -524,20 +525,10 @@ func TestContract_Age_RotateKeys_CleanupFailureSurfacesError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Render the parent directory read-only AFTER first rotation
-	// is fully done to make a SECOND rotation fail in cleanup.
-	// A read-only dir prevents new files / renames in either
-	// direction, which is too aggressive — the second rotation
-	// cannot even Phase 3-rename. So instead we exercise the
-	// path differently: place a directory exactly where one of
-	// the backups will land so os.Rename fails at Phase 3, and
-	// confirm Phase 0 / Phase 3 produce a clean error (no
-	// half-committed state). The cleanup-failure path itself is
-	// straightforward (two os.Remove calls + error wrap), and
-	// the integration test covered by NoLeftoverBackups proves
-	// the happy path. This test pins the contract that ANY
-	// rename-aside failure during Phase 3 returns an error and
-	// leaves the originals on disk untouched.
+	// Stage a directory at the destination of one of the backup
+	// renames. Phase 0 sees something at the path (os.Stat returns
+	// nil error for directories) and refuses with the leftover
+	// message. The originals are not touched.
 	dirAtBackupPath := filepath.Join(dir, "talm.key.rotation-backup")
 	if err := os.MkdirAll(dirAtBackupPath, 0o755); err != nil {
 		t.Fatal(err)
@@ -556,8 +547,6 @@ func TestContract_Age_RotateKeys_CleanupFailureSurfacesError(t *testing.T) {
 	if err := age.RotateKeys(dir); err == nil {
 		t.Fatal("expected RotateKeys to fail when a directory blocks the backup path")
 	}
-	// Originals must still be on disk untouched (Phase 0 refusal
-	// or Phase 3 rollback preserved them).
 	gotKey, err := os.ReadFile(filepath.Join(dir, "talm.key"))
 	if err != nil {
 		t.Fatalf("talm.key missing after failed rotation: %v", err)

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -483,6 +483,55 @@ func TestContract_Age_RotateKeys_BothFilesMode0600(t *testing.T) {
 	}
 }
 
+// Contract: EncryptSecretsFile produces secrets.encrypted.yaml at
+// mode 0o600. Pinning so all three code paths that write the same
+// file (this function, RotateKeys, EncryptYAMLFile) agree on the
+// same defense-in-depth permission. Skipped on Windows for the
+// same NTFS reason as BothFilesMode0600.
+func TestContract_Age_EncryptSecretsFile_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not honoured on NTFS; secureperm has a Windows-side DACL test that covers the equivalent contract")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptSecretsFile(dir); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "secrets.encrypted.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("secrets.encrypted.yaml mode = %o, want 0600", got)
+	}
+}
+
+// Contract: EncryptYAMLFile produces its target encrypted file at
+// mode 0o600. Same defense-in-depth contract as
+// EncryptSecretsFile — the function is the generic kubeconfig /
+// arbitrary-YAML variant of the secrets-encrypt path.
+func TestContract_Age_EncryptYAMLFile_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not honoured on NTFS; secureperm has a Windows-side DACL test that covers the equivalent contract")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("k: v\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptYAMLFile(dir, "kubeconfig.yaml", "kubeconfig.encrypted.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "kubeconfig.encrypted.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("kubeconfig.encrypted.yaml mode = %o, want 0600", got)
+	}
+}
+
 // Contract: a successful rotation leaves NO `*.rotation-backup`
 // files in the project root. Backups are an in-progress recovery
 // artefact only; their presence after the function returns nil

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -494,11 +494,93 @@ func TestContract_Age_RotateKeys_NoLeftoverBackups(t *testing.T) {
 	}
 }
 
+// Contract: when the post-commit cleanup of `*.rotation-backup`
+// files fails (e.g. a permissions flip on the parent dir between
+// the commit and the os.Remove), RotateKeys returns a non-nil
+// error explaining "rotation committed but cleanup failed" and
+// instructing the operator to remove the leftovers manually
+// before the next rotation. The new key + encrypted file on disk
+// are still the rotated pair — only the backups linger.
+//
+// Failure injection: chmod the project dir to 0o500 right before
+// the cleanup step would run. We approximate this by triggering
+// the cleanup-failed code path indirectly: stage a directory at
+// the backup path so os.Remove (which expects a regular file)
+// fails. This is brittle but the only injection point reachable
+// without modifying the function signature.
+//
+// Skipped under root because chmod-on-directory-content does not
+// constrain euid 0; the test would always succeed in unhelpful
+// ways.
+func TestContract_Age_RotateKeys_CleanupFailureSurfacesError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — directory permissions and os.Remove behaviour differ")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptSecretsFile(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Render the parent directory read-only AFTER first rotation
+	// is fully done to make a SECOND rotation fail in cleanup.
+	// A read-only dir prevents new files / renames in either
+	// direction, which is too aggressive — the second rotation
+	// cannot even Phase 3-rename. So instead we exercise the
+	// path differently: place a directory exactly where one of
+	// the backups will land so os.Rename fails at Phase 3, and
+	// confirm Phase 0 / Phase 3 produce a clean error (no
+	// half-committed state). The cleanup-failure path itself is
+	// straightforward (two os.Remove calls + error wrap), and
+	// the integration test covered by NoLeftoverBackups proves
+	// the happy path. This test pins the contract that ANY
+	// rename-aside failure during Phase 3 returns an error and
+	// leaves the originals on disk untouched.
+	dirAtBackupPath := filepath.Join(dir, "talm.key.rotation-backup")
+	if err := os.MkdirAll(dirAtBackupPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dirAtBackupPath) }()
+
+	originalKey, err := os.ReadFile(filepath.Join(dir, "talm.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalEnc, err := os.ReadFile(filepath.Join(dir, "secrets.encrypted.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := age.RotateKeys(dir); err == nil {
+		t.Fatal("expected RotateKeys to fail when a directory blocks the backup path")
+	}
+	// Originals must still be on disk untouched (Phase 0 refusal
+	// or Phase 3 rollback preserved them).
+	gotKey, err := os.ReadFile(filepath.Join(dir, "talm.key"))
+	if err != nil {
+		t.Fatalf("talm.key missing after failed rotation: %v", err)
+	}
+	gotEnc, err := os.ReadFile(filepath.Join(dir, "secrets.encrypted.yaml"))
+	if err != nil {
+		t.Fatalf("secrets.encrypted.yaml missing after failed rotation: %v", err)
+	}
+	if string(gotKey) != string(originalKey) {
+		t.Errorf("talm.key changed despite failed rotation")
+	}
+	if string(gotEnc) != string(originalEnc) {
+		t.Errorf("secrets.encrypted.yaml changed despite failed rotation")
+	}
+}
+
 // Contract: if a `*.rotation-backup` file is present at the start
-// (operator's previous rotation crashed mid-flight), the new run
-// refuses to start with a precise error pointing at the leftover
-// path. This protects the recovery state from being silently
-// overwritten by the second run.
+// of a run, RotateKeys refuses with a precise error pointing at
+// the leftover path. The error wording covers both possible
+// origins of the leftover (interrupted run OR successful run with
+// failed cleanup), so the operator does not need to consult two
+// different recovery procedures. This protects the recovery state
+// from being silently overwritten by the second run.
 func TestContract_Age_RotateKeys_RefusesOnLeftoverBackup(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
@@ -520,6 +602,11 @@ func TestContract_Age_RotateKeys_RefusesOnLeftoverBackup(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "rotation-backup") {
 		t.Errorf("error must reference the leftover backup path, got: %v", err)
+	}
+	// The error must mention BOTH possible origins of the leftover
+	// so the operator can disambiguate without consulting docs.
+	if !strings.Contains(err.Error(), "interrupted") || !strings.Contains(err.Error(), "cleanup") {
+		t.Errorf("error must mention both 'interrupted' and 'cleanup' as possible origins, got: %v", err)
 	}
 	// The leftover must still be on disk — refusal must not delete it.
 	if _, statErr := os.Stat(leftover); statErr != nil {

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -32,6 +32,7 @@ package age_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -450,7 +451,17 @@ func TestContract_Age_RotateKeys_ReplacesKeyAndPreservesPlaintext(t *testing.T) 
 // secrets material on shared workstations invites mistakes. Pin so
 // a regression that reverts the secureperm.WriteFile call to a raw
 // os.WriteFile with 0o644 surfaces here.
+//
+// Skipped on Windows: NTFS does not honour Unix permission bits,
+// so os.FileInfo.Mode().Perm() always returns 0o666 regardless of
+// the actual DACL. The secureperm package has its own Windows-side
+// owner-only DACL test (pkg/secureperm/secureperm_windows_test.go)
+// that exercises the equivalent contract via the platform's
+// security descriptor APIs.
 func TestContract_Age_RotateKeys_BothFilesMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not honoured on NTFS; secureperm has a Windows-side DACL test that covers the equivalent contract")
+	}
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -388,21 +388,13 @@ func TestContract_Age_SecretsFile_ChangedValueLocalizedDiff(t *testing.T) {
 
 // === RotateKeys ===
 
-// Contract: RotateKeys preserves plaintext round-trip after the
-// call: whatever key happens to be on disk afterwards is sufficient
-// to decrypt the encrypted file. This is the minimum integrity
-// guarantee operators rely on.
-//
-// KNOWN BUG (not pinned, on purpose): RotateKeys at age.go:485 does
-// NOT actually replace talm.key. It calls GenerateKey, which is a
-// load-or-create operation: if talm.key already exists,
-// GenerateKey loads and returns it instead of generating a fresh
-// identity. So today RotateKeys re-encrypts the secrets file with
-// the SAME key. The test does not assert "public key changes" — if
-// it did, this would fail today, and pinning a passing assertion
-// would lock in the bug. Track separately and fix in a dedicated
-// commit.
-func TestContract_Age_RotateKeys_PreservesPlaintextRoundTrip(t *testing.T) {
+// Contract: RotateKeys actually rotates the on-disk key — the
+// public key after the call is different from before — AND the
+// plaintext round-trips end-to-end with whatever key is on disk
+// afterwards. The test exercises both invariants so a regression
+// that reintroduces the load-or-create no-op surfaces as the
+// public-key inequality fail.
+func TestContract_Age_RotateKeys_ReplacesKeyAndPreservesPlaintext(t *testing.T) {
 	dir := t.TempDir()
 	plain := []byte("secret: rotate-me\n")
 	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), plain, 0o600); err != nil {
@@ -411,9 +403,22 @@ func TestContract_Age_RotateKeys_PreservesPlaintextRoundTrip(t *testing.T) {
 	if err := age.EncryptSecretsFile(dir); err != nil {
 		t.Fatal(err)
 	}
+	oldPub, err := age.GetPublicKeyFromFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := age.RotateKeys(dir); err != nil {
 		t.Fatalf("RotateKeys: %v", err)
+	}
+
+	// Public key must have changed — the whole point of rotation.
+	newPub, err := age.GetPublicKeyFromFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldPub == newPub {
+		t.Errorf("RotateKeys did not replace the on-disk key\nold: %s\nnew: %s", oldPub, newPub)
 	}
 
 	// Decrypt with whatever key is on disk now — plaintext must round-trip.

--- a/pkg/age/contract_test.go
+++ b/pkg/age/contract_test.go
@@ -444,6 +444,89 @@ func TestContract_Age_RotateKeys_ReplacesKeyAndPreservesPlaintext(t *testing.T) 
 	}
 }
 
+// Contract: after a successful rotation both the new key file and
+// the new encrypted secrets file are mode 0o600. Defense-in-depth
+// — age encryption is the security layer, but world-readable
+// secrets material on shared workstations invites mistakes. Pin so
+// a regression that reverts the secureperm.WriteFile call to a raw
+// os.WriteFile with 0o644 surfaces here.
+func TestContract_Age_RotateKeys_BothFilesMode0600(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptSecretsFile(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.RotateKeys(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"talm.key", "secrets.encrypted.yaml"} {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("%s mode = %o, want 0600", name, got)
+		}
+	}
+}
+
+// Contract: a successful rotation leaves NO `*.rotation-backup`
+// files in the project root. Backups are an in-progress recovery
+// artefact only; their presence after the function returns nil
+// would clutter the project and confuse subsequent runs.
+func TestContract_Age_RotateKeys_NoLeftoverBackups(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptSecretsFile(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.RotateKeys(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"talm.key.rotation-backup", "secrets.encrypted.yaml.rotation-backup"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			t.Errorf("rotation left backup file %q on disk", name)
+		}
+	}
+}
+
+// Contract: if a `*.rotation-backup` file is present at the start
+// (operator's previous rotation crashed mid-flight), the new run
+// refuses to start with a precise error pointing at the leftover
+// path. This protects the recovery state from being silently
+// overwritten by the second run.
+func TestContract_Age_RotateKeys_RefusesOnLeftoverBackup(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secrets.yaml"), []byte("secret: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := age.EncryptSecretsFile(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an interrupted previous rotation by creating a
+	// dangling `talm.key.rotation-backup`.
+	leftover := filepath.Join(dir, "talm.key.rotation-backup")
+	if err := os.WriteFile(leftover, []byte("orphaned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := age.RotateKeys(dir)
+	if err == nil {
+		t.Fatal("expected RotateKeys to refuse with leftover backup present")
+	}
+	if !strings.Contains(err.Error(), "rotation-backup") {
+		t.Errorf("error must reference the leftover backup path, got: %v", err)
+	}
+	// The leftover must still be on disk — refusal must not delete it.
+	if _, statErr := os.Stat(leftover); statErr != nil {
+		t.Errorf("leftover backup was removed despite refusal: %v", statErr)
+	}
+}
+
 // === EncryptYAMLFile / DecryptYAMLFile ===
 
 // Contract: the generic file-pair encrypt/decrypt accepts arbitrary

--- a/pkg/commands/contract_helpers_test.go
+++ b/pkg/commands/contract_helpers_test.go
@@ -39,26 +39,26 @@ import (
 // kubelet/kube-proxy port is hardcoded to 6443.
 func TestContract_NormalizeEndpoint(t *testing.T) {
 	cases := []struct {
-		in, want string
+		name, in, want string
 	}{
-		{"1.2.3.4", "https://1.2.3.4:6443"},
-		{"1.2.3.4:50000", "https://1.2.3.4:6443"},
-		{"https://1.2.3.4:50000", "https://1.2.3.4:6443"},
-		{"http://1.2.3.4", "https://1.2.3.4:6443"},
-		{"https://node.example.com:6443", "https://node.example.com:6443"},
-		{"node.example.com", "https://node.example.com:6443"},
+		{"ipv4_no_port", "1.2.3.4", "https://1.2.3.4:6443"},
+		{"ipv4_with_port", "1.2.3.4:50000", "https://1.2.3.4:6443"},
+		{"ipv4_https_with_port", "https://1.2.3.4:50000", "https://1.2.3.4:6443"},
+		{"ipv4_http", "http://1.2.3.4", "https://1.2.3.4:6443"},
+		{"hostname_https_canonical", "https://node.example.com:6443", "https://node.example.com:6443"},
+		{"hostname_no_port", "node.example.com", "https://node.example.com:6443"},
 		// IPv6 with brackets — net.JoinHostPort re-adds them for any
 		// host containing a colon, so the canonical output is
 		// "https://[2001:db8::1]:6443". URI-bracketed IPv6 literals
 		// per RFC 3986 §3.2.2.
-		{"[2001:db8::1]:6443", "https://[2001:db8::1]:6443"},
+		{"ipv6_bracketed_with_port", "[2001:db8::1]:6443", "https://[2001:db8::1]:6443"},
 		// IPv6 without explicit port — bare bracketed literal. The
 		// no-port branch strips the outer brackets so JoinHostPort
 		// can add exactly one pair back.
-		{"[2001:db8::1]", "https://[2001:db8::1]:6443"},
+		{"ipv6_bracketed_no_port", "[2001:db8::1]", "https://[2001:db8::1]:6443"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			got := normalizeEndpoint(tc.in)
 			if got != tc.want {
 				t.Errorf("normalizeEndpoint(%q) = %q, want %q", tc.in, got, tc.want)

--- a/pkg/commands/contract_helpers_test.go
+++ b/pkg/commands/contract_helpers_test.go
@@ -47,16 +47,15 @@ func TestContract_NormalizeEndpoint(t *testing.T) {
 		{"http://1.2.3.4", "https://1.2.3.4:6443"},
 		{"https://node.example.com:6443", "https://node.example.com:6443"},
 		{"node.example.com", "https://node.example.com:6443"},
-		// IPv6 with brackets — net.SplitHostPort returns the bracket-
-		// stripped host, and the current normalizeEndpoint does NOT
-		// re-add them, producing a malformed URL. Pinning the broken
-		// output deliberately so a later fix surfaces here. Tracked
-		// in issue #155 — when normalizeEndpoint switches to
-		// net.JoinHostPort, the expected value below becomes
-		// "https://[2001:db8::1]:6443" and the test starts asserting
-		// the canonical form.
-		// FIXME(#155): expected URL is malformed (missing brackets).
-		{"[2001:db8::1]:6443", "https://2001:db8::1:6443"},
+		// IPv6 with brackets — net.JoinHostPort re-adds them for any
+		// host containing a colon, so the canonical output is
+		// "https://[2001:db8::1]:6443". URI-bracketed IPv6 literals
+		// per RFC 3986 §3.2.2.
+		{"[2001:db8::1]:6443", "https://[2001:db8::1]:6443"},
+		// IPv6 without explicit port — bare bracketed literal. The
+		// no-port branch strips the outer brackets so JoinHostPort
+		// can add exactly one pair back.
+		{"[2001:db8::1]", "https://[2001:db8::1]:6443"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {

--- a/pkg/commands/talosctl_wrapper.go
+++ b/pkg/commands/talosctl_wrapper.go
@@ -227,15 +227,22 @@ func normalizeEndpoint(endpoint string) string {
 	endpoint = strings.TrimPrefix(endpoint, "https://")
 	endpoint = strings.TrimPrefix(endpoint, "http://")
 
-	// Split host and port
+	// Split host and port. net.SplitHostPort strips IPv6 brackets,
+	// so the host returned may be a bare IPv6 literal that needs
+	// re-bracketing for the URL form.
 	host, _, err := net.SplitHostPort(endpoint)
 	if err != nil {
-		// No port in endpoint, use as-is
-		host = endpoint
+		// No port in endpoint. Strip an outer pair of brackets if
+		// present so the JoinHostPort below adds them back exactly
+		// once for IPv6 literals.
+		host = strings.TrimPrefix(strings.TrimSuffix(endpoint, "]"), "[")
 	}
 
-	// Return normalized endpoint with https:// and :6443 port
-	return fmt.Sprintf("https://%s:6443", host)
+	// Use net.JoinHostPort to assemble — it bracketed IPv6 hosts
+	// automatically (per RFC 3986 §3.2.2). Without this an IPv6
+	// endpoint produced an unparseable URL like
+	// "https://2001:db8::1:6443" instead of "https://[2001:db8::1]:6443".
+	return "https://" + net.JoinHostPort(host, "6443")
 }
 
 // updateKubeconfigServer updates the server field in all clusters of the kubeconfig file

--- a/pkg/commands/talosctl_wrapper.go
+++ b/pkg/commands/talosctl_wrapper.go
@@ -216,12 +216,20 @@ func init() {
 	}
 }
 
-// normalizeEndpoint normalizes an endpoint by removing any existing port and protocol, then adding https:// and :6443
+// normalizeEndpoint normalizes an endpoint by removing any existing
+// port and protocol, then adding https:// and :6443. IPv6 literals
+// are bracketed per RFC 3986 §3.2.2 (the assembly uses
+// net.JoinHostPort which auto-bracket-wraps any host that contains
+// a colon).
+//
 // Examples:
-//   - "1.2.3.4" -> "https://1.2.3.4:6443"
-//   - "1.2.3.4:50000" -> "https://1.2.3.4:6443"
-//   - "https://1.2.3.4:50000" -> "https://1.2.3.4:6443"
-//   - "http://1.2.3.4" -> "https://1.2.3.4:6443"
+//   - "1.2.3.4"                       -> "https://1.2.3.4:6443"
+//   - "1.2.3.4:50000"                 -> "https://1.2.3.4:6443"
+//   - "https://1.2.3.4:50000"         -> "https://1.2.3.4:6443"
+//   - "http://1.2.3.4"                -> "https://1.2.3.4:6443"
+//   - "node.example.com"              -> "https://node.example.com:6443"
+//   - "[2001:db8::1]:6443"            -> "https://[2001:db8::1]:6443"
+//   - "[2001:db8::1]"                 -> "https://[2001:db8::1]:6443"
 func normalizeEndpoint(endpoint string) string {
 	// Remove protocol if present
 	endpoint = strings.TrimPrefix(endpoint, "https://")

--- a/pkg/engine/contract_debugphase_test.go
+++ b/pkg/engine/contract_debugphase_test.go
@@ -1,0 +1,105 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract: debugPhase tolerates empty patch entries in its input
+// slice. Templates that conditionally emit nothing legitimately
+// produce "" in the slice; the original implementation indexed
+// patch[0] without a length guard and panicked at runtime, which
+// happened ONLY under --debug — the worst possible time to crash.
+
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+)
+
+// TestContract_DebugPhase_TolerantOfEmptyPatch runs debugPhase as a
+// subprocess (it calls os.Exit(0) at the end so cannot be exercised
+// in-process) and asserts:
+//
+//   - exit code is 0 (graceful exit, not a panic)
+//   - no "runtime error" or "index out of range" in stderr
+//   - the surviving non-empty patches are still printed
+//
+// Re-entry uses the os.Args[0]+TEST_DEBUG_PHASE_HELPER pattern from
+// Go's own stdlib tests (e.g. os/exec_test.go).
+func TestContract_DebugPhase_TolerantOfEmptyPatch(t *testing.T) {
+	if os.Getenv("TEST_DEBUG_PHASE_HELPER") == "1" {
+		// Child process: invoke debugPhase with a slice that contains
+		// an empty patch sandwiched between two non-empty ones. The
+		// pre-fix implementation would panic on patch[0] for the
+		// empty entry. With the fix, the empty entry is skipped and
+		// the surrounding entries are printed.
+		debugPhase(
+			Options{},
+			[]string{"machine:\n  type: worker", "", "machine:\n  type: controlplane"},
+			"test-cluster",
+			"https://example.com:6443",
+			machine.TypeWorker,
+		)
+		return // unreachable, debugPhase calls os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestContract_DebugPhase_TolerantOfEmptyPatch$")
+	cmd.Env = append(os.Environ(), "TEST_DEBUG_PHASE_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("debugPhase subprocess failed: %v\noutput:\n%s", err, out)
+	}
+	output := string(out)
+	if strings.Contains(output, "runtime error") || strings.Contains(output, "index out of range") {
+		t.Errorf("debugPhase panicked on empty patch:\n%s", output)
+	}
+	// The non-empty patches must still appear in output (one as
+	// machine.type=worker, the other as type=controlplane). Order is
+	// preserved.
+	if !strings.Contains(output, "type: worker") {
+		t.Errorf("expected first non-empty patch in output:\n%s", output)
+	}
+	if !strings.Contains(output, "type: controlplane") {
+		t.Errorf("expected last non-empty patch in output:\n%s", output)
+	}
+}
+
+// TestContract_DebugPhase_HandlesAllEmpty verifies the all-empty
+// slice — the loop simply skips every entry, debugPhase prints the
+// header then exits 0. Pinning so a refactor that errors on
+// "no patches printed" surfaces here.
+func TestContract_DebugPhase_HandlesAllEmpty(t *testing.T) {
+	if os.Getenv("TEST_DEBUG_PHASE_HELPER_ALL_EMPTY") == "1" {
+		debugPhase(
+			Options{},
+			[]string{"", "", ""},
+			"test-cluster",
+			"https://example.com:6443",
+			machine.TypeWorker,
+		)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestContract_DebugPhase_HandlesAllEmpty$")
+	cmd.Env = append(os.Environ(), "TEST_DEBUG_PHASE_HELPER_ALL_EMPTY=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("debugPhase subprocess failed on all-empty input: %v\noutput:\n%s", err, out)
+	}
+	if strings.Contains(string(out), "runtime error") {
+		t.Errorf("debugPhase panicked on all-empty input:\n%s", out)
+	}
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -94,9 +94,15 @@ func debugPhase(opts Options, patches []string, clusterName string, clusterEndpo
 		patchOption = "--config-patch-worker"
 	}
 
-	// Print patches
+	// Print patches. Skip empty entries — a template that conditionally
+	// emits nothing legitimately produces "" in the slice, and indexing
+	// patch[0] on an empty string would panic right at the moment the
+	// operator is using --debug to investigate something.
 	for _, patch := range patches {
-		if string(patch[0]) == "@" {
+		if patch == "" {
+			continue
+		}
+		if patch[0] == '@' {
 			// Apply patch is always one
 			fmt.Printf(" %s=%s\n", patchOption, patch)
 		} else {


### PR DESCRIPTION
## Summary

Three Go-side bug fixes covering `RotateKeys` atomicity (#151 + #159), `debugPhase` panic on empty patch (#152), and `normalizeEndpoint` IPv6 bracketing (#155). Each fix replaces a previously-pinned-as-broken contract test with a real-behaviour pin, so a regression that reverts any fix surfaces in CI.

## Fixes

### `pkg/age.RotateKeys` — closes #151 and #159

The original implementation called `GenerateKey()` expecting a fresh identity, but `GenerateKey` is load-or-create: with `talm.key` already on disk it loaded the existing identity instead of generating a new one. Rotation was a silent no-op — the same key encrypted every secret after the alleged rotation.

The fix is **atomic transaction with backup/restore**:

1. Read encrypted file, decrypt with old key (in memory).
2. Generate new identity, encrypt new ciphertext (in memory).
3. Atomic-rename originals aside as `*.rotation-backup`.
4. Write new key + encrypted file via `secureperm.WriteFile` (atomic temp+rename, mode `0o600`). Failures here trigger a `restore` closure that puts the backups back.
5. Remove backups; failure here returns an explicit "rotation committed but cleanup failed" error so the next run is not confused by the leftovers.

Phase 0 refuses to start when leftover `*.rotation-backup` files are present, with an error that names both possible origins (interrupted run or successful run with failed cleanup) so the operator picks the right recovery path.

Adjacent fix in the same function: `secrets.encrypted.yaml` is now written via `secureperm.WriteFile` so it lands at mode `0o600` (was `0o644` — pre-existing, defense-in-depth). The same switch is applied to `EncryptSecretsFile` and `EncryptYAMLFile` so all three code paths that write encrypted secrets material agree on the same on-disk mode.

Tests pin: public key inequality, plaintext round-trip, both files at `0o600` (with Windows skip — NTFS does not honour Unix permission bits), no leftover backups on success, refusal on leftover backups (with both-origins error wording), refusal when something occupies the backup destination.

### `pkg/engine.debugPhase` — closes #152

`debugPhase` indexed `patch[0]` without a length guard. A template that conditionally emits nothing legitimately produces `""` in the slice; the runtime panic surfaced ONLY under `--debug` — exactly when the operator was using the flag to investigate something. Skip empty entries before the dispatch.

Test runs the helper as a subprocess (it calls `os.Exit(0)`) using the `os.Args[0]` + env-sentinel pattern from `os/exec_test.go`. Two cases: empty sandwiched between non-empty (asserts surrounding output preserved + no panic), all-empty (asserts header-only path).

### `pkg/commands.normalizeEndpoint` — closes #155

`net.SplitHostPort` strips IPv6 brackets and the old `fmt.Sprintf` did not re-add them, so `[2001:db8::1]:6443` became the unparseable `https://2001:db8::1:6443`. Switch to `net.JoinHostPort` which auto-bracket-wraps any host containing a colon. RFC 3986 §3.2.2 compliant.

Docstring updated to include IPv6 examples (now visible in godoc, not just in the implementation comment).

Test pinned-as-broken `FIXME(#155)` case rewritten to assert canonical `https://[2001:db8::1]:6443`; new no-port IPv6 case `[2001:db8::1]` exercises the strip-then-rebracket path. Subtests renamed to descriptive labels for unambiguous test output.
