### PR TITLE
fix(commands): refuse init inside ancestor project, all-or-nothing pre-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ cd newcluster
 talm init -p cozystack -N myawesomecluster
 ```
 
+`talm init` refuses to run when the current directory is inside an existing talm project (it would otherwise walk up and partially overwrite the parent). To create a project under the current directory anyway — e.g. a sub-project nested inside another talm project — pass `--root .` explicitly. To re-initialise the parent itself, run `talm init` from the parent directory.
+
 To pin a specific Talos installer image at init time (e.g. a [Talos Factory](https://factory.talos.dev/) image with extensions), pass `--image`:
 
 ```bash

--- a/pkg/commands/contract_init_ux_test.go
+++ b/pkg/commands/contract_init_ux_test.go
@@ -1,0 +1,333 @@
+// Copyright Cozystack Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract: `talm init` UX guards.
+//
+// 1. PreRunE refuses when CWD is inside an existing talm project but
+//    --root was not set explicitly. Otherwise DetectAndSetRoot would
+//    walk up to the ancestor project and init would silently write
+//    new files into it.
+//
+// 2. RunE pre-checks every destination path BEFORE the first write
+//    so the command is all-or-nothing — no partial-init state if any
+//    destination already exists.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// === PreRunE refusal on ancestor project ===
+
+// Contract: when CWD is inside an existing talm project (ancestor
+// has Chart.yaml + secrets.yaml) and the operator did NOT pass
+// --root, init refuses with an error that names both paths and
+// tells the operator how to proceed (--root . to create here,
+// or move up to re-init the ancestor).
+func TestContract_InitPreRun_RefusesWhenInsideAncestorProject(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	// Stage an ancestor talm project, chdir into a sub-dir of it.
+	root := t.TempDir()
+	makeProjectRoot(t, root)
+	subdir := filepath.Join(root, "deep", "deeper")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	// Simulate DetectAndSetRoot having walked up to the ancestor.
+	rootAbs, _ := filepath.Abs(root)
+	Config.RootDir = rootAbs
+	Config.RootDirExplicit = false
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	err := initCmd.PreRunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected PreRunE to refuse when CWD is inside an ancestor project")
+	}
+	if !strings.Contains(err.Error(), "inside an existing talm project") {
+		t.Errorf("error must explain CWD-is-inside-project, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--root .") {
+		t.Errorf("error must point at --root . as the workaround, got: %v", err)
+	}
+	// Both paths should appear so the operator can see what was detected.
+	subdirAbs, _ := filepath.Abs(subdir)
+	if !strings.Contains(err.Error(), subdirAbs) {
+		t.Errorf("error must name the CWD path %q, got: %v", subdirAbs, err)
+	}
+	if !strings.Contains(err.Error(), rootAbs) {
+		t.Errorf("error must name the ancestor project path %q, got: %v", rootAbs, err)
+	}
+}
+
+// Contract: when --root was set explicitly, the ancestor-project
+// guard does NOT fire — the operator has clearly opted in to a
+// specific root. This is the escape hatch the refusal error
+// suggests ("pass --root . explicitly").
+func TestContract_InitPreRun_RootExplicitSkipsAncestorCheck(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	root := t.TempDir()
+	makeProjectRoot(t, root)
+	subdir := filepath.Join(root, "deep")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	// --root explicit, pointing at a different location than the
+	// detected ancestor.
+	Config.RootDir = subdir
+	Config.RootDirExplicit = true
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	if err := initCmd.PreRunE(initCmd, nil); err != nil {
+		t.Errorf("expected PreRunE to pass with --root explicit, got: %v", err)
+	}
+}
+
+// Contract: when CWD itself IS the project root (no ancestor walk
+// needed), init proceeds normally. Pin so a regression that fires
+// the refusal whenever ancestor != "" surfaces here.
+func TestContract_InitPreRun_AcceptsWhenCWDIsRoot(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	dirAbs, _ := filepath.Abs(dir)
+
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = false
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	if err := initCmd.PreRunE(initCmd, nil); err != nil {
+		t.Errorf("expected PreRunE to pass when CWD is the root, got: %v", err)
+	}
+}
+
+// === RunE pre-check before any write ===
+
+// Contract: when ANY destination path already exists (without
+// --force), `talm init` aborts BEFORE the first write. Files that
+// the previous behaviour would have created (talosconfig, talm.key,
+// secrets.encrypted.yaml) MUST NOT be on disk after the failed
+// init. The error lists every conflict so the operator sees the
+// full picture.
+//
+// Stage one conflict (Chart.yaml) inside a fresh root and assert:
+// 1. RunE returns an error mentioning the conflict.
+// 2. None of the otherwise-created files (talosconfig, talm.key,
+//    .gitignore, secrets.encrypted.yaml) exist after the run.
+func TestContract_InitRun_PreCheckRejectsBeforeAnyWrite(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	dirAbs, _ := filepath.Abs(dir)
+	t.Chdir(dirAbs)
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = true // bypass the ancestor check
+	Config.InitOptions.Version = "v0.0.0-test"
+
+	// Stage one conflict.
+	if err := os.WriteFile(filepath.Join(dirAbs, "Chart.yaml"), []byte("name: pre-existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.force = false
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	err := initCmd.RunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected RunE to fail when a destination already exists")
+	}
+	if !strings.Contains(err.Error(), "refusing to init") {
+		t.Errorf("error must mention 'refusing to init', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Chart.yaml") {
+		t.Errorf("error must name the conflicting Chart.yaml, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error must point at --force as the workaround, got: %v", err)
+	}
+
+	// None of the otherwise-created files must exist on disk.
+	for _, name := range []string{"talosconfig", "talm.key", "secrets.encrypted.yaml", "secrets.yaml", "values.yaml"} {
+		if _, statErr := os.Stat(filepath.Join(dirAbs, name)); statErr == nil {
+			t.Errorf("partial-write detected: %q exists after pre-check rejection", name)
+		}
+	}
+}
+
+// Contract: --encrypt operates on an ALREADY INITIALISED project,
+// where every preset file is expected to exist on disk. The
+// pre-check must NOT fire for --encrypt — running it there would
+// refuse the very flow the flag is designed for. Pin so a
+// regression that drops the encrypt-skip surfaces here.
+//
+// The test stages a "looks initialised" project (Chart.yaml,
+// values.yaml, secrets.yaml, charts/talm/Chart.yaml) and asserts
+// that RunE under --encrypt does NOT return a "refusing to init"
+// error. The full encrypt flow may still fail on adjacent
+// steps unrelated to the pre-check; the contract here is
+// specifically that the pre-check does not block.
+func TestContract_InitRun_EncryptBypassesPreCheck(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	dirAbs, _ := filepath.Abs(dir)
+	t.Chdir(dirAbs)
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = true
+
+	// Stage looks-initialised state so the pre-check would fire if
+	// it were not gated.
+	for _, name := range []string{"Chart.yaml", "values.yaml", "secrets.yaml"} {
+		if err := os.WriteFile(filepath.Join(dirAbs, name), []byte("seed\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dirAbs, "charts", "talm"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirAbs, "charts", "talm", "Chart.yaml"), []byte("name: talm\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	initCmdFlags.encrypt = true
+	initCmdFlags.force = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.preset = ""
+	initCmdFlags.name = ""
+	initCmdFlags.image = ""
+
+	err := initCmd.RunE(initCmd, nil)
+	if err != nil && strings.Contains(err.Error(), "refusing to init") {
+		t.Errorf("--encrypt must bypass the preset pre-check, got: %v", err)
+	}
+}
+
+// Contract: --decrypt operates on the same ALREADY INITIALISED
+// project shape and likewise must not fire the pre-check. Pin so
+// the decrypt-skip is enforced symmetrically with --encrypt.
+func TestContract_InitRun_DecryptBypassesPreCheck(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	dirAbs, _ := filepath.Abs(dir)
+	t.Chdir(dirAbs)
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = true
+
+	for _, name := range []string{"Chart.yaml", "values.yaml", "secrets.encrypted.yaml"} {
+		if err := os.WriteFile(filepath.Join(dirAbs, name), []byte("seed\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dirAbs, "charts", "talm"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirAbs, "charts", "talm", "Chart.yaml"), []byte("name: talm\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	initCmdFlags.decrypt = true
+	initCmdFlags.force = false
+	initCmdFlags.encrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.preset = ""
+	initCmdFlags.name = ""
+	initCmdFlags.image = ""
+
+	err := initCmd.RunE(initCmd, nil)
+	if err != nil && strings.Contains(err.Error(), "refusing to init") {
+		t.Errorf("--decrypt must bypass the preset pre-check, got: %v", err)
+	}
+}
+
+// Contract: when --force is set, the pre-check is bypassed and the
+// existing destinations are overwritten. Pin so a regression that
+// always pre-checks (ignoring --force) surfaces here. The full
+// init flow involves PKI generation and chart writes that take a
+// real second; we only need to assert the pre-check did NOT
+// reject — the existing TestWriteToDestination_* / Init flow tests
+// cover the rest.
+func TestContract_InitRun_ForceBypassesPreCheck(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	dirAbs, _ := filepath.Abs(dir)
+	t.Chdir(dirAbs)
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = true
+	Config.InitOptions.Version = "v0.0.0-test"
+
+	// Stage one conflict — Chart.yaml.
+	if err := os.WriteFile(filepath.Join(dirAbs, "Chart.yaml"), []byte("name: pre-existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.force = true // <- bypass
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	err := initCmd.RunE(initCmd, nil)
+	// The full init flow may succeed or fail for unrelated reasons
+	// (PKI generation cost, secrets bundle generation). The contract
+	// here is specifically that the pre-check did NOT reject — i.e.
+	// the error, if any, does NOT mention "refusing to init".
+	if err != nil && strings.Contains(err.Error(), "refusing to init") {
+		t.Errorf("--force should bypass the pre-check, got: %v", err)
+	}
+}

--- a/pkg/commands/contract_init_ux_test.go
+++ b/pkg/commands/contract_init_ux_test.go
@@ -28,6 +28,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -153,9 +154,9 @@ func TestContract_InitPreRun_AcceptsWhenCWDIsRoot(t *testing.T) {
 // full picture.
 //
 // Stage one conflict (Chart.yaml) inside a fresh root and assert:
-// 1. RunE returns an error mentioning the conflict.
-// 2. None of the otherwise-created files (talosconfig, talm.key,
-//    .gitignore, secrets.encrypted.yaml) exist after the run.
+//  1. RunE returns an error mentioning the conflict.
+//  2. None of the otherwise-created files (talosconfig, talm.key,
+//     .gitignore, secrets.encrypted.yaml) exist after the run.
 func TestContract_InitRun_PreCheckRejectsBeforeAnyWrite(t *testing.T) {
 	withInitFlagsSnapshot(t)
 	withConfigSnapshot(t)
@@ -199,6 +200,189 @@ func TestContract_InitRun_PreCheckRejectsBeforeAnyWrite(t *testing.T) {
 		if _, statErr := os.Stat(filepath.Join(dirAbs, name)); statErr == nil {
 			t.Errorf("partial-write detected: %q exists after pre-check rejection", name)
 		}
+	}
+}
+
+// Contract: when the operator stages MULTIPLE conflicting destinations
+// (Chart.yaml AND values.yaml AND charts/talm/Chart.yaml), the pre-check
+// must list ALL of them in the error message — not bail at the first.
+// The runtime sorts the slice with slices.Sort before joining, so the
+// error is deterministic regardless of map-iteration order. Pin both
+// the all-listed and the deterministic-order properties.
+func TestContract_InitRun_PreCheckListsAllConflicts(t *testing.T) {
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	dir := t.TempDir()
+	dirAbs, _ := filepath.Abs(dir)
+	t.Chdir(dirAbs)
+	Config.RootDir = dirAbs
+	Config.RootDirExplicit = true
+	Config.InitOptions.Version = "v0.0.0-test"
+
+	// Stage three conflicts in distinct chart locations so the pre-check
+	// must visit and report each one. charts/talm/Chart.yaml exercises
+	// the library-chart dispatch arm; Chart.yaml and values.yaml exercise
+	// the preset arm.
+	stagedFiles := []string{
+		filepath.Join(dirAbs, "Chart.yaml"),
+		filepath.Join(dirAbs, "values.yaml"),
+		filepath.Join(dirAbs, "charts", "talm", "Chart.yaml"),
+	}
+	for _, p := range stagedFiles {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("name: pre-existing\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+	initCmdFlags.force = false
+	initCmdFlags.encrypt = false
+	initCmdFlags.decrypt = false
+	initCmdFlags.update = false
+	initCmdFlags.image = ""
+
+	err := initCmd.RunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected RunE to fail with multiple conflicts")
+	}
+
+	// Every staged path must be named in the error. Skipping any one
+	// would mean the operator has to re-run init multiple times to
+	// discover the full conflict set.
+	for _, p := range stagedFiles {
+		if !strings.Contains(err.Error(), p) {
+			t.Errorf("error must list conflict %q, got: %v", p, err)
+		}
+	}
+
+	// Deterministic order: the conflicts must appear sorted, so two
+	// invocations against the same on-disk state produce byte-identical
+	// errors. With slices.Sort applied to absolute paths, the
+	// charts/talm/Chart.yaml entry sorts before Chart.yaml in the same
+	// dir because "/" < "Y" — assert the listing order matches a
+	// fresh sort of the same staged set.
+	expectedOrder := append([]string{}, stagedFiles...)
+	for i := range expectedOrder {
+		expectedOrder[i], _ = filepath.Abs(expectedOrder[i])
+	}
+	// Use the same sort the runtime uses.
+	for i := range expectedOrder {
+		for j := i + 1; j < len(expectedOrder); j++ {
+			if expectedOrder[i] > expectedOrder[j] {
+				expectedOrder[i], expectedOrder[j] = expectedOrder[j], expectedOrder[i]
+			}
+		}
+	}
+	first, last := expectedOrder[0], expectedOrder[len(expectedOrder)-1]
+	firstIdx := strings.Index(err.Error(), first)
+	lastIdx := strings.Index(err.Error(), last)
+	if firstIdx == -1 || lastIdx == -1 || firstIdx >= lastIdx {
+		t.Errorf("conflicts not in sorted order: %q must appear before %q in: %v", first, last, err)
+	}
+}
+
+// Contract: when os.Getwd() fails, PreRunE returns the wrapped error
+// rather than fail-open into the partial-overlay risk that #156 was
+// about.
+//
+// Reproducer: chdir into a temp dir, remove that dir, then call PreRunE.
+// On Linux the kernel returns ENOENT from getcwd(2); the guard wraps it.
+//
+// Linux-only:
+//   - Windows refuses to remove a directory any process has as its CWD,
+//     so the kernel-level setup the test depends on is unavailable.
+//   - macOS getcwd(3) returns the cached path even after rmdir, so
+//     Getwd does NOT fail. The fail-closed branch is unreachable from
+//     a unit test on Darwin without injecting the error via a stub.
+//     The contract still has to hold cross-platform — we just pin it
+//     here on the platform CI runs (ubuntu-latest), which is the
+//     authoritative gate.
+func TestContract_InitPreRun_FailsClosedOnGetwd(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("Getwd-on-removed-dir reproducer is Linux-only (windows: cannot remove CWD; darwin: getcwd survives rmdir); GOOS=%s", runtime.GOOS)
+	}
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	parent := t.TempDir()
+	sub := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+	if err := os.Remove(sub); err != nil {
+		t.Fatal(err)
+	}
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+
+	err := initCmd.PreRunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected PreRunE to fail when CWD has been removed")
+	}
+	if !strings.Contains(err.Error(), "current working directory") {
+		t.Errorf("error must mention current working directory failure, got: %v", err)
+	}
+}
+
+// Contract: when filepath.Abs(Config.RootDir) fails because the relative
+// path resolution calls os.Getwd internally and that fails, PreRunE
+// returns the wrapped error. Pinned because the production code's
+// Config.RootDir defaults to "." (relative) — the abs-path resolution
+// for a relative input is an os.Getwd round-trip and inherits the same
+// TOCTOU exposure as the explicit Getwd call above it.
+//
+// Reproducer: same shape as the Getwd contract — chdir into a removed
+// directory. The first os.Getwd in the guard would also fail, but
+// hitting the second guard requires its own coverage so a future
+// refactor that makes the first one survive (e.g. by caching at startup)
+// does not silently fail-open through the second.
+//
+// Linux-only: same constraints as the Getwd test above. Windows
+// cannot remove the CWD; darwin getcwd survives rmdir. Linux CI is
+// the authoritative gate.
+func TestContract_InitPreRun_FailsClosedOnAbsRootDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("Abs-on-relative-path-with-removed-CWD reproducer is Linux-only; GOOS=%s", runtime.GOOS)
+	}
+	withInitFlagsSnapshot(t)
+	withConfigSnapshot(t)
+
+	parent := t.TempDir()
+	sub := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+	if err := os.Remove(sub); err != nil {
+		t.Fatal(err)
+	}
+	// Force Config.RootDir to a relative path so filepath.Abs has to
+	// call os.Getwd internally. This is the production default ("."),
+	// not a synthetic shape.
+	Config.RootDir = "."
+	Config.RootDirExplicit = false
+
+	initCmdFlags.preset = "cozystack"
+	initCmdFlags.name = "test-cluster"
+
+	err := initCmd.PreRunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected PreRunE to fail when Config.RootDir is relative and CWD is removed")
+	}
+	// Either the first Getwd guard or the second Abs(Config.RootDir)
+	// guard fires depending on the kernel: both wrap with a clear
+	// message. Assert at least one of the two phrases appears so a
+	// future refactor that swaps the order still keeps the contract.
+	msg := err.Error()
+	if !strings.Contains(msg, "current working directory") && !strings.Contains(msg, "project root") {
+		t.Errorf("error must mention CWD or project root resolution failure, got: %v", err)
 	}
 }
 

--- a/pkg/commands/contract_root_dispatch_test.go
+++ b/pkg/commands/contract_root_dispatch_test.go
@@ -59,11 +59,13 @@ func withConfigSnapshot(t *testing.T) {
 	rootDirExplicit := Config.RootDirExplicit
 	talosconfig := GlobalArgs.Talosconfig
 	talosconfigCfg := Config.GlobalOptions.Talosconfig
+	initOptions := Config.InitOptions
 	t.Cleanup(func() {
 		Config.RootDir = rootDir
 		Config.RootDirExplicit = rootDirExplicit
 		GlobalArgs.Talosconfig = talosconfig
 		Config.GlobalOptions.Talosconfig = talosconfigCfg
+		Config.InitOptions = initOptions
 	})
 }
 
@@ -277,6 +279,53 @@ func TestContract_CheckRootConflict_ExplicitConflict(t *testing.T) {
 }
 
 // === DetectAndSetRoot ===
+
+// Contract: when --root is declared as a PERSISTENT flag on a
+// parent command (rootCmd), DetectAndSetRoot must observe its
+// "Changed" state through cmd.Flags() (which includes inherited
+// persistent flags), not cmd.PersistentFlags() (which lists ONLY
+// flags declared persistent on cmd itself). The bug version did
+// the latter — Changed("root") was always false on subcommands,
+// so RootDirExplicit stayed false and the CWD walk-up always
+// fired, defeating the operator's --root opt-in. Pin the
+// inherited-persistent-flag observation behaviour.
+func TestContract_DetectAndSetRoot_RootInheritedPersistentFlag(t *testing.T) {
+	withConfigSnapshot(t)
+
+	root := t.TempDir()
+	makeProjectRoot(t, root)
+	subdir := filepath.Join(root, "deep")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	// Mirror main.go's flag layout: --root declared as persistent on
+	// the parent command via StringVar(&Config.RootDir, ...), the
+	// subcommand inherits it through cmd.Flags() but NOT
+	// cmd.PersistentFlags().
+	parent := &cobra.Command{Use: "talm"}
+	parent.PersistentFlags().StringVar(&Config.RootDir, "root", ".", "")
+	child := &cobra.Command{Use: "init"}
+	parent.AddCommand(child)
+
+	if err := parent.PersistentFlags().Set("root", subdir); err != nil {
+		t.Fatal(err)
+	}
+	withOSArgs(t, []string{"talm", "init"})
+
+	if err := DetectAndSetRoot(child, nil); err != nil {
+		t.Fatalf("DetectAndSetRoot: %v", err)
+	}
+	if !Config.RootDirExplicit {
+		t.Error("RootDirExplicit must be true when --root was set on the inherited persistent flag")
+	}
+	// Strategy 3 (CWD walk-up) is gated by !Explicit and must NOT
+	// have fired — Config.RootDir stays at whatever --root pointed at.
+	if Config.RootDir != subdir {
+		t.Errorf("RootDir = %q; expected %q (the --root value, not the walk-up result)", Config.RootDir, subdir)
+	}
+}
 
 // Contract: DetectAndSetRoot with a -f flag pointing at a file under
 // a project root sets Config.RootDir to that root. The flag wins

--- a/pkg/commands/contract_root_dispatch_test.go
+++ b/pkg/commands/contract_root_dispatch_test.go
@@ -147,7 +147,7 @@ func TestContract_GetFlagValues_RegisteredButUnset(t *testing.T) {
 
 // === detectRootFromFiles / detectRootFromTemplates / detectRootFromCWD ===
 
-// Contract: empty input yields ('', nil) — caller falls through to
+// Contract: empty input yields ("", nil) — caller falls through to
 // the next detection strategy.
 func TestContract_DetectRootFromFiles_EmptyInput(t *testing.T) {
 	got, err := detectRootFromFiles(nil)

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -111,6 +111,30 @@ var initCmd = &cobra.Command{
 		if errs := validation.IsDNS1123Subdomain(initCmdFlags.name); len(errs) > 0 {
 			return fmt.Errorf("--name %q is not a valid DNS-1123 subdomain: %s", initCmdFlags.name, strings.Join(errs, "; "))
 		}
+
+		// Refuse to init when CWD is inside an existing talm project but
+		// the operator did not pass --root explicitly. DetectAndSetRoot
+		// (run earlier on this command) walks up from CWD to find a
+		// project root, which is right for `apply` / `template` /
+		// `talosconfig` but wrong for `init` — without this guard, init
+		// silently writes new files into the ancestor project and
+		// partially overwrites it. The operator is almost certainly
+		// trying to create a NEW project under CWD; tell them how.
+		//
+		// Bail out if os.Getwd() fails: this is the only point where
+		// the guard can compare CWD against the detected ancestor;
+		// silently skipping it on a getwd error would fail-open and
+		// reintroduce the partial-overlay risk this guard exists to
+		// prevent.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to determine current working directory: %w", err)
+		}
+		absCwd, _ := filepath.Abs(cwd)
+		absRootDir, _ := filepath.Abs(Config.RootDir)
+		if !Config.RootDirExplicit && absRootDir != absCwd {
+			return fmt.Errorf("refusing to init: %q is inside an existing talm project at %q. To create a new project under the current directory, pass --root . explicitly. To re-initialise the parent, run from the parent directory", absCwd, absRootDir)
+		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -158,6 +182,60 @@ var initCmd = &cobra.Command{
 			genOptions = append(genOptions, generate.WithVersionContract(versionContract))
 		}
 		genOptions = append(genOptions, generate.WithSecretsBundle(secretsBundle))
+
+		// Pre-check every preset-loop destination so a fresh init is
+		// all-or-nothing for the chart artefacts. Without this, the
+		// previous behaviour failed at the first conflict (typically
+		// Chart.yaml) AFTER talosconfig / talm.key /
+		// secrets.encrypted.yaml were already on disk — leaving the
+		// project in a partially-initialised state scripted callers
+		// could not recover from. Files written outside the preset
+		// loop (talosconfig, talm.key, secrets.*, kubeconfig.*,
+		// .gitignore, nodes/) are not pre-checked here; each has its
+		// own per-file existence handling downstream and the dominant
+		// failure mode (Chart.yaml conflict) is what this pre-check
+		// addresses.
+		//
+		// Skipped under --encrypt / --decrypt: those flags operate on
+		// an already-initialised project where every preset file is
+		// expected to exist. Running the pre-check there would refuse
+		// the very flows the flags are designed for. Load presetFiles
+		// up-front in either case so the later write loop can reuse
+		// the same map.
+		presetFiles, err := generated.PresetFiles()
+		if err != nil {
+			return fmt.Errorf("failed to get preset files: %w", err)
+		}
+		if !initCmdFlags.force && !initCmdFlags.encrypt && !initCmdFlags.decrypt {
+			var conflicts []string
+			for path := range presetFiles {
+				parts := strings.SplitN(path, "/", 2)
+				chartName := parts[0]
+				var dest string
+				// Library chart files always land under charts/talm/.
+				// Checked first so a hypothetical preset literally
+				// named "talm" cannot collide with the library
+				// chart's destination (AvailablePresets excludes
+				// "talm" today, but the dispatch should not depend
+				// on that invariant).
+				switch chartName {
+				case "talm":
+					dest = filepath.Join(Config.RootDir, "charts", path)
+				case initCmdFlags.preset:
+					dest = filepath.Join(Config.RootDir, filepath.Join(parts[1:]...))
+				default:
+					continue
+				}
+				if _, statErr := os.Stat(dest); statErr == nil {
+					conflicts = append(conflicts, dest)
+				}
+			}
+			if len(conflicts) > 0 {
+				slices.Sort(conflicts)
+				return fmt.Errorf("refusing to init: %d file(s) already exist in target directory; pass --force to overwrite, or --update to refresh only the talm library chart:\n  - %s",
+					len(conflicts), strings.Join(conflicts, "\n  - "))
+			}
+		}
 
 		// Handle age encryption logic
 		secretsFile := filepath.Join(Config.RootDir, "secrets.yaml")
@@ -425,10 +503,8 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to create nodes directory: %w", err)
 		}
 
-		presetFiles, err := generated.PresetFiles()
-		if err != nil {
-			return fmt.Errorf("failed to get preset files: %w", err)
-		}
+		// presetFiles was loaded up-front for the pre-check above and
+		// is reused here for the write loop.
 
 		// Validate --image up-front so a flag/preset mismatch fails
 		// the command before any file is written.

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -130,8 +130,20 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to determine current working directory: %w", err)
 		}
-		absCwd, _ := filepath.Abs(cwd)
-		absRootDir, _ := filepath.Abs(Config.RootDir)
+		absCwd, err := filepath.Abs(cwd)
+		if err != nil {
+			return fmt.Errorf("failed to resolve absolute path of current working directory: %w", err)
+		}
+		// Config.RootDir may be a relative path (defaults to ".");
+		// filepath.Abs calls os.Getwd internally for relative inputs,
+		// which can fail under TOCTOU (CWD removed between the call
+		// above and here). Treat that the same as the Getwd guard
+		// above — fail closed rather than silently zero out absRootDir
+		// and let the comparison go the wrong way.
+		absRootDir, err := filepath.Abs(Config.RootDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve absolute path of project root %q: %w", Config.RootDir, err)
+		}
 		if !Config.RootDirExplicit && absRootDir != absCwd {
 			// %s, not %q: %q calls strconv.Quote which escapes
 			// backslashes in Windows paths (C:\Users\... renders as

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -215,41 +215,45 @@ var initCmd = &cobra.Command{
 		// Skipped under --encrypt / --decrypt: those flags operate on
 		// an already-initialised project where every preset file is
 		// expected to exist. Running the pre-check there would refuse
-		// the very flows the flags are designed for. Load presetFiles
-		// up-front in either case so the later write loop can reuse
-		// the same map.
-		presetFiles, err := generated.PresetFiles()
-		if err != nil {
-			return fmt.Errorf("failed to get preset files: %w", err)
-		}
-		if !initCmdFlags.force && !initCmdFlags.encrypt && !initCmdFlags.decrypt {
-			var conflicts []string
-			for path := range presetFiles {
-				parts := strings.SplitN(path, "/", 2)
-				chartName := parts[0]
-				var dest string
-				// Library chart files always land under charts/talm/.
-				// Checked first so a hypothetical preset literally
-				// named "talm" cannot collide with the library
-				// chart's destination (AvailablePresets excludes
-				// "talm" today, but the dispatch should not depend
-				// on that invariant).
-				switch chartName {
-				case "talm":
-					dest = filepath.Join(Config.RootDir, "charts", path)
-				case initCmdFlags.preset:
-					dest = filepath.Join(Config.RootDir, filepath.Join(parts[1:]...))
-				default:
-					continue
-				}
-				if _, statErr := os.Stat(dest); statErr == nil {
-					conflicts = append(conflicts, dest)
-				}
+		// the very flows the flags are designed for. Both flags
+		// also early-return below before the write loop reaches
+		// presetFiles, so loading the map at all is wasted work
+		// under those flags — gate the load on the same condition.
+		var presetFiles map[string]string
+		if !initCmdFlags.encrypt && !initCmdFlags.decrypt {
+			presetFiles, err = generated.PresetFiles()
+			if err != nil {
+				return fmt.Errorf("failed to get preset files: %w", err)
 			}
-			if len(conflicts) > 0 {
-				slices.Sort(conflicts)
-				return fmt.Errorf("refusing to init: %d file(s) already exist in target directory; pass --force to overwrite, or --update to refresh only the talm library chart:\n  - %s",
-					len(conflicts), strings.Join(conflicts, "\n  - "))
+			if !initCmdFlags.force {
+				var conflicts []string
+				for path := range presetFiles {
+					parts := strings.SplitN(path, "/", 2)
+					chartName := parts[0]
+					var dest string
+					// Library chart files always land under charts/talm/.
+					// Checked first so a hypothetical preset literally
+					// named "talm" cannot collide with the library
+					// chart's destination (AvailablePresets excludes
+					// "talm" today, but the dispatch should not depend
+					// on that invariant).
+					switch chartName {
+					case "talm":
+						dest = filepath.Join(Config.RootDir, "charts", path)
+					case initCmdFlags.preset:
+						dest = filepath.Join(Config.RootDir, filepath.Join(parts[1:]...))
+					default:
+						continue
+					}
+					if _, statErr := os.Stat(dest); statErr == nil {
+						conflicts = append(conflicts, dest)
+					}
+				}
+				if len(conflicts) > 0 {
+					slices.Sort(conflicts)
+					return fmt.Errorf("refusing to init: %d file(s) already exist in target directory; pass --force to overwrite, or --update to refresh only the talm library chart:\n  - %s",
+						len(conflicts), strings.Join(conflicts, "\n  - "))
+				}
 			}
 		}
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -133,7 +133,11 @@ var initCmd = &cobra.Command{
 		absCwd, _ := filepath.Abs(cwd)
 		absRootDir, _ := filepath.Abs(Config.RootDir)
 		if !Config.RootDirExplicit && absRootDir != absCwd {
-			return fmt.Errorf("refusing to init: %q is inside an existing talm project at %q. To create a new project under the current directory, pass --root . explicitly. To re-initialise the parent, run from the parent directory", absCwd, absRootDir)
+			// %s, not %q: %q calls strconv.Quote which escapes
+			// backslashes in Windows paths (C:\Users\... renders as
+			// "C:\\Users\\..."), making the message harder to read
+			// for the operator and breaking substring tests.
+			return fmt.Errorf("refusing to init: %s is inside an existing talm project at %s. To create a new project under the current directory, pass --root . explicitly. To re-initialise the parent, run from the parent directory", absCwd, absRootDir)
 		}
 		return nil
 	},

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -229,6 +229,17 @@ var initCmd = &cobra.Command{
 				var conflicts []string
 				for path := range presetFiles {
 					parts := strings.SplitN(path, "/", 2)
+					// PresetFiles walks an embed.FS so it only ever
+					// returns real file paths (chart/file...), never
+					// bare directory entries. Defensive guard anyway:
+					// if a future change to PresetFiles ever surfaced a
+					// path with no separator, parts[1:] would be empty
+					// and dest would resolve to Config.RootDir — which
+					// always exists, producing a guaranteed false
+					// positive that blocks every init.
+					if len(parts) < 2 {
+						continue
+					}
 					chartName := parts[0]
 					var dest string
 					// Library chart files always land under charts/talm/.

--- a/pkg/commands/root_detection.go
+++ b/pkg/commands/root_detection.go
@@ -129,8 +129,21 @@ func checkRootConflict(detectedRoot string, rootDirExplicit bool) error {
 // 2. From -t/--template flag (if templates specified)
 // 3. From current working directory
 func DetectAndSetRoot(cmd *cobra.Command, args []string) error {
-	// Check if --root was explicitly set
-	Config.RootDirExplicit = cmd.PersistentFlags().Changed("root")
+	// Check if --root was explicitly set. Use cmd.Flag(name).Changed
+	// rather than cmd.PersistentFlags().Changed("root"):
+	// PersistentFlags lists ONLY flags declared persistent on cmd
+	// itself, but --root is declared on rootCmd as a persistent
+	// flag, so for any subcommand other than rootCmd itself,
+	// cmd.PersistentFlags().Changed("root") returned false even
+	// when the operator passed --root explicitly — the entire
+	// "operator opted in to a specific root" escape hatch was
+	// effectively dead. cmd.Flag(name) walks the inheritance chain
+	// (local -> persistent -> parent persistent) and returns the
+	// merged flag definition with its real Changed state.
+	Config.RootDirExplicit = false
+	if flag := cmd.Flag("root"); flag != nil {
+		Config.RootDirExplicit = flag.Changed
+	}
 
 	// Get file paths from -f/--file flag
 	configFiles := getFlagValues(cmd, "file")


### PR DESCRIPTION
Closes #156, closes #157.

## What

`talm init` walked up to the parent project and partially overwrote it (#156), and exited 0 even when only some preset files were written (#157). This PR adds four defensive layers, each fail-closed, so the failure modes can no longer go unnoticed:

1. **Ancestor-project refusal in PreRunE.** When the current directory is inside an existing talm project, `init` refuses to run. The error names both paths (CWD and the discovered ancestor root) and points at the documented opt-in: `--root .` to create a project under CWD anyway, or `cd` to the ancestor root to re-initialise it.
2. **All-or-nothing pre-check in RunE.** Before any write, walk the embedded preset's file list, resolve every entry to its on-disk destination using the same rules as the write loop (`charts/talm/...` for the library chart, the operator's `--root` for everything else, skip presets that will not be written), and refuse with a sorted list of conflicts when any destination exists. Bypassed by `--force` (overwrite), `--update` (refresh library only), `--encrypt`, and `--decrypt` (operate on already-initialised state, must not be blocked).
3. **Inherited persistent flag observation.** `--root` is declared persistent on `rootCmd` only. The previous check used `cmd.PersistentFlags().Changed("root")`, which lists ONLY flags declared persistent on `cmd` itself, so on every subcommand it returned false — making the operator's `--root .` opt-in a dead end exactly when the new error message advertised it. Switched to `cmd.Flag("root").Changed`, which walks the inheritance chain.
4. **Fail-closed `os.Getwd()`.** When `Getwd` fails, the PreRunE guard returns the error instead of silently skipping the ancestor check, so the partial-overlay risk cannot quietly re-emerge.

## Tests

Each guard is pinned by a contract test that fails without the corresponding fix. Coverage:

- `RefusesWhenInsideAncestorProject`, `RootExplicitSkipsAncestorCheck`, `AcceptsWhenCWDIsRoot`
- `PreCheckRejectsBeforeAnyWrite`, `PreCheckListsAllConflicts`
- `EncryptBypassesPreCheck`, `DecryptBypassesPreCheck`, `ForceBypassesPreCheck`
- `DetectAndSetRoot_RootInheritedPersistentFlag` mirrors `main.go`'s parent/child cobra layout (`StringVar(&Config.RootDir, ...)` on the parent's `PersistentFlags`, child added via `AddCommand`) and asserts both that `RootDirExplicit` lands true and that the CWD walk-up does not fire.

`withConfigSnapshot` also now captures `Config.InitOptions` so preset-version overrides used by the pre-check tests do not leak between tests.

## Docs

README documents the ancestor-refusal behaviour and points at `--root .` as the documented opt-in, matching the runtime error message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `talm init` now supports `--root .` flag to enable initialization in nested sub-projects while working within a parent project directory.

* **Bug Fixes**
  * `talm init` now refuses to run when the current directory is inside an existing project, preventing accidental partial overwrites of ancestor projects.
  * Pre-validation checks now occur before any files are written, ensuring failures halt before data changes.

* **Documentation**
  * Updated getting started guide with clarifications on `talm init` behavior and nested project initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/talm/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->