### PR TITLE
fix(cozystack): exclude loop devices from LVM global_filter

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -110,7 +110,7 @@ machine:
         archive = 0
       }
       devices {
-         global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+         global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
       }
   {{- with .Values.extraMachineFiles }}
   {{- toYaml . | nindent 2 }}

--- a/pkg/engine/contract_machine_test.go
+++ b/pkg/engine/contract_machine_test.go
@@ -630,8 +630,10 @@ func TestContract_Machine_CertSANs_LoopbackUnconditional_Cozystack(t *testing.T)
 //     plugin paths. Required for SR-IOV / GPU device plugins to
 //     surface inside privileged containers.
 //  2. /etc/lvm/lvm.conf — disables LVM backup/archive and sets a
-//     global_filter that excludes drbd, dm-, zd- devices. Required so
-//     LVM does not race the storage stack at boot.
+//     global_filter that excludes drbd, dm-, zd-, loop devices.
+//     Required so LVM does not race the storage stack at boot, and
+//     so the host never activates a volume group living inside a
+//     loop-mounted image.
 //
 // Both files use op: create / op: overwrite respectively. A regression
 // removing either silently breaks GPU/SRIOV or LVM ordering.
@@ -651,6 +653,7 @@ func TestContract_Machine_Files_Cozystack(t *testing.T) {
 			assertContains(t, out, `r|^/dev/drbd.*|`)
 			assertContains(t, out, `r|^/dev/dm-.*|`)
 			assertContains(t, out, `r|^/dev/zd.*|`)
+			assertContains(t, out, `r|^/dev/loop.*|`)
 		})
 	}
 }


### PR DESCRIPTION
Add `/dev/loop` to the LVM `global_filter` in the generated Talos machine config so the host does not scan or activate volume groups located inside loop-mounted images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * LVM configuration updated to filter out loop devices (now excludes /dev/loop.* alongside existing patterns).
* **Tests**
  * Expanded test coverage to assert the LVM configuration includes the loop-device exclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/talm/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->